### PR TITLE
[upstream] Revolute and prismatic targets (box2d #929)

### DIFF
--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkBarrel.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkBarrel.cs
@@ -51,8 +51,8 @@ public class BenchmarkBarrel : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(8.0f, 53.0f);
-            m_context.camera.m_zoom = 25.0f * 2.35f;
+            m_camera.m_center = new B2Vec2(8.0f, 53.0f);
+            m_camera.m_zoom = 25.0f * 2.35f;
         }
 
         m_context.settings.drawJoints = false;
@@ -311,7 +311,7 @@ public class BenchmarkBarrel : Sample
         base.UpdateGui();
         
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(220.0f, height));
         ImGui.Begin("Benchmark: Barrel", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
@@ -54,8 +54,8 @@ public class BenchmarkCast : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(500.0f, 500.0f);
-            m_context.camera.m_zoom = 25.0f * 21.0f;
+            m_camera.m_center = new B2Vec2(500.0f, 500.0f);
+            m_camera.m_zoom = 25.0f * 21.0f;
             // m_context.settings.drawShapes = m_context.g_sampleDebug;
         }
 
@@ -227,12 +227,12 @@ public class BenchmarkCast : Sample
 
             B2Vec2 p1 = m_origins[m_drawIndex];
             B2Vec2 p2 = p1 + m_translations[m_drawIndex];
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
-            m_context.draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
             if (drawResult.hit)
             {
-                m_context.draw.DrawPoint(drawResult.point, 5.0f, B2HexColor.b2_colorWhite);
+                m_draw.DrawPoint(drawResult.point, 5.0f, B2HexColor.b2_colorWhite);
             }
         }
         else if (m_queryType == QueryType.e_circleCast)
@@ -266,14 +266,14 @@ public class BenchmarkCast : Sample
 
             B2Vec2 p1 = m_origins[m_drawIndex];
             B2Vec2 p2 = p1 + m_translations[m_drawIndex];
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
-            m_context.draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
             if (drawResult.hit)
             {
                 B2Vec2 t = b2Lerp(p1, p2, drawResult.fraction);
-                m_context.draw.DrawCircle(t, m_radius, B2HexColor.b2_colorWhite);
-                m_context.draw.DrawPoint(drawResult.point, 5.0f, B2HexColor.b2_colorWhite);
+                m_draw.DrawCircle(t, m_radius, B2HexColor.b2_colorWhite);
+                m_draw.DrawPoint(drawResult.point, 5.0f, B2HexColor.b2_colorWhite);
             }
         }
         else if (m_queryType == QueryType.e_overlap)
@@ -310,12 +310,12 @@ public class BenchmarkCast : Sample
                 B2Vec2 origin = m_origins[m_drawIndex];
                 B2AABB aabb = new B2AABB(origin - extent, origin + extent);
 
-                m_context.draw.DrawAABB(aabb, B2HexColor.b2_colorWhite);
+                m_draw.DrawAABB(aabb, B2HexColor.b2_colorWhite);
             }
 
             for (int i = 0; i < drawResult.count; ++i)
             {
-                m_context.draw.DrawPoint(drawResult.points[i], 5.0f, B2HexColor.b2_colorHotPink);
+                m_draw.DrawPoint(drawResult.points[i], 5.0f, B2HexColor.b2_colorHotPink);
             }
         }
     }
@@ -325,7 +325,7 @@ public class BenchmarkCast : Sample
         base.UpdateGui();
 
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Cast", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCompound.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCompound.cs
@@ -23,8 +23,8 @@ public class BenchmarkCompound : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(18.0f, 115.0f);
-            m_context.camera.m_zoom = 25.0f * 5.5f;
+            m_camera.m_center = new B2Vec2(18.0f, 115.0f);
+            m_camera.m_zoom = 25.0f * 5.5f;
         }
 
         float grid = 1.0f;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCreateDestroy.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCreateDestroy.cs
@@ -37,8 +37,8 @@ public class BenchmarkCreateDestroy : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 50.0f);
-            m_context.camera.m_zoom = 25.0f * 2.2f;
+            m_camera.m_center = new B2Vec2(0.0f, 50.0f);
+            m_camera.m_zoom = 25.0f * 2.2f;
         }
 
         float groundSize = 100.0f;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkJointGrid.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkJointGrid.cs
@@ -19,8 +19,8 @@ public class BenchmarkJointGrid : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(60.0f, -57.0f);
-            m_context.camera.m_zoom = 25.0f * 2.5f;
+            m_camera.m_center = new B2Vec2(60.0f, -57.0f);
+            m_camera.m_zoom = 25.0f * 2.5f;
             m_context.settings.enableSleep = false;
         }
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkKinematic.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkKinematic.cs
@@ -23,8 +23,8 @@ public class BenchmarkKinematic : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 150.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 150.0f;
         }
 
         float grid = 1.0f;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkLargePyramid.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkLargePyramid.cs
@@ -19,8 +19,8 @@ public class BenchmarkLargePyramid : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 50.0f);
-            m_context.camera.m_zoom = 25.0f * 2.2f;
+            m_camera.m_center = new B2Vec2(0.0f, 50.0f);
+            m_camera.m_zoom = 25.0f * 2.2f;
             m_context.settings.enableSleep = false;
         }
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyPyramids.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyPyramids.cs
@@ -19,8 +19,8 @@ public class BenchmarkManyPyramids : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(16.0f, 110.0f);
-            m_context.camera.m_zoom = 25.0f * 5.0f;
+            m_camera.m_center = new B2Vec2(16.0f, 110.0f);
+            m_camera.m_zoom = 25.0f * 5.0f;
             m_context.settings.enableSleep = false;
         }
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyTumblers.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyTumblers.cs
@@ -43,8 +43,8 @@ public class BenchmarkManyTumblers : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(1.0f, -5.5f);
-            m_context.camera.m_zoom = 25.0f * 3.4f;
+            m_camera.m_center = new B2Vec2(1.0f, -5.5f);
+            m_camera.m_zoom = 25.0f * 3.4f;
             m_context.settings.drawJoints = false;
         }
 
@@ -143,7 +143,7 @@ public class BenchmarkManyTumblers : Sample
         base.UpdateGui();
         
         float height = 110.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
         ImGui.Begin("Benchmark: Many Tumblers", ImGuiWindowFlags.NoResize);
         ImGui.PushItemWidth(100.0f);

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkRain.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkRain.cs
@@ -22,8 +22,8 @@ public class BenchmarkRain : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 110.0f);
-            m_context.camera.m_zoom = 125.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 110.0f);
+            m_camera.m_zoom = 125.0f;
             m_context.settings.enableSleep = true;
         }
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSensor.cs
@@ -39,8 +39,8 @@ public class BenchmarkSensor : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 105.0f);
-            m_context.camera.m_zoom = 125.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 105.0f);
+            m_camera.m_zoom = 125.0f;
         }
 
         m_passiveSensor.shouldDestroyVisitors = false;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
@@ -39,8 +39,8 @@ public class BenchmarkShapeDistance : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 3.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 3.0f;
         }
 
         {
@@ -101,7 +101,7 @@ public class BenchmarkShapeDistance : Sample
     public override void UpdateGui()
     {
         float height = 80.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(220.0f, height));
         ImGui.Begin("Benchmark: Shape Distance", ImGuiWindowFlags.NoResize);
 
@@ -158,12 +158,12 @@ public class BenchmarkShapeDistance : Sample
         B2Transform xfA = m_transformAs[m_drawIndex];
         B2Transform xfB = m_transformBs[m_drawIndex];
         B2DistanceOutput output = m_outputs[m_drawIndex];
-        m_context.draw.DrawSolidPolygon(ref xfA, m_polygonA.vertices.AsSpan(), m_polygonA.count, m_polygonA.radius, B2HexColor.b2_colorBox2DGreen);
-        m_context.draw.DrawSolidPolygon(ref xfB, m_polygonB.vertices.AsSpan(), m_polygonB.count, m_polygonB.radius, B2HexColor.b2_colorBox2DBlue);
-        m_context.draw.DrawSegment(output.pointA, output.pointB, B2HexColor.b2_colorDimGray);
-        m_context.draw.DrawPoint(output.pointA, 10.0f, B2HexColor.b2_colorWhite);
-        m_context.draw.DrawPoint(output.pointB, 10.0f, B2HexColor.b2_colorWhite);
-        m_context.draw.DrawSegment(output.pointA, output.pointA + 0.5f * output.normal, B2HexColor.b2_colorYellow);
+        m_draw.DrawSolidPolygon(ref xfA, m_polygonA.vertices.AsSpan(), m_polygonA.count, m_polygonA.radius, B2HexColor.b2_colorBox2DGreen);
+        m_draw.DrawSolidPolygon(ref xfB, m_polygonB.vertices.AsSpan(), m_polygonB.count, m_polygonB.radius, B2HexColor.b2_colorBox2DBlue);
+        m_draw.DrawSegment(output.pointA, output.pointB, B2HexColor.b2_colorDimGray);
+        m_draw.DrawPoint(output.pointA, 10.0f, B2HexColor.b2_colorWhite);
+        m_draw.DrawPoint(output.pointB, 10.0f, B2HexColor.b2_colorWhite);
+        m_draw.DrawSegment(output.pointA, output.pointA + 0.5f * output.normal, B2HexColor.b2_colorYellow);
         DrawTextLine($"distance = {output.distance}");
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSleep.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSleep.cs
@@ -40,8 +40,8 @@ public class BenchmarkSleep : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 50.0f);
-            m_context.camera.m_zoom = 25.0f * 2.2f;
+            m_camera.m_center = new B2Vec2(0.0f, 50.0f);
+            m_camera.m_zoom = 25.0f * 2.2f;
         }
 
         float groundSize = 100.0f;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSmash.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSmash.cs
@@ -30,8 +30,8 @@ public class BenchmarkSmash : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(60.0f, 6.0f);
-            m_context.camera.m_zoom = 25.0f * 1.6f;
+            m_camera.m_center = new B2Vec2(60.0f, 6.0f);
+            m_camera.m_zoom = 25.0f * 1.6f;
         }
 
         m_rowCount = m_isDebug ? 10 : 80;
@@ -59,7 +59,7 @@ public class BenchmarkSmash : Sample
         base.UpdateGui();
 
         float height = 110.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(220.0f, height));
         ImGui.Begin("Benchmark: Smash", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSpinner.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSpinner.cs
@@ -19,8 +19,8 @@ public class BenchmarkSpinner : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 32.0f);
-            m_context.camera.m_zoom = 42.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 32.0f);
+            m_camera.m_zoom = 42.0f;
         }
 
         // b2_toiCalls = 0;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkTumbler.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkTumbler.cs
@@ -19,8 +19,8 @@ public class BenchmarkTumbler : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(1.5f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.6f;
+            m_camera.m_center = new B2Vec2(1.5f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.6f;
         }
 
         CreateTumbler(m_worldId);

--- a/src/Box2D.NET.Samples/Samples/Bodies/BadBody.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/BadBody.cs
@@ -25,8 +25,8 @@ public class BadBody : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.3f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(2.3f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         B2BodyId groundId = b2_nullBodyId;

--- a/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
@@ -37,8 +37,8 @@ public class BodyType : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.8f, 6.4f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.8f, 6.4f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         m_type = B2BodyType.b2_dynamicBody;
@@ -204,7 +204,7 @@ public class BodyType : Sample
 
 
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
         ImGui.Begin("Body Type", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Bodies/Kinematic.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Kinematic.cs
@@ -26,8 +26,8 @@ public class Kinematic : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 4.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 4.0f;
         }
 
         m_amplitude = 2.0f;
@@ -74,8 +74,8 @@ public class Kinematic : Sample
             B2Rot rotation = b2MakeRot(2.0f * m_time);
 
             B2Vec2 axis = b2RotateVector(rotation, new B2Vec2(0.0f, 1.0f));
-            m_context.draw.DrawSegment(point - 0.5f * axis, point + 0.5f * axis, B2HexColor.b2_colorPlum);
-            m_context.draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorPlum);
+            m_draw.DrawSegment(point - 0.5f * axis, point + 0.5f * axis, B2HexColor.b2_colorPlum);
+            m_draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorPlum);
 
             b2Body_SetTargetTransform(m_bodyId, new B2Transform(point, rotation), m_timeStep);
         }

--- a/src/Box2D.NET.Samples/Samples/Bodies/Pivot.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Pivot.cs
@@ -28,8 +28,8 @@ public class Pivot : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.8f, 6.4f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.8f, 6.4f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         B2BodyId groundId = b2_nullBodyId;

--- a/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
@@ -34,8 +34,8 @@ public class Sleep : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(3.0f, 50.0f);
-            m_context.camera.m_zoom = 25.0f * 2.2f;
+            m_camera.m_center = new B2Vec2(3.0f, 50.0f);
+            m_camera.m_zoom = 25.0f * 2.2f;
         }
 
         B2BodyId groundId = b2_nullBodyId;
@@ -175,7 +175,7 @@ public class Sleep : Sample
     {
         base.UpdateGui();
         float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
         ImGui.Begin("Sleep", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
@@ -32,8 +32,8 @@ public class Weeble : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.3f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(2.3f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         // Test friction and restitution callbacks
@@ -95,7 +95,7 @@ public class Weeble : Sample
         base.UpdateGui();
         
         float height = 120.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
         ImGui.Begin("Weeble", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
         if (ImGui.Button("Teleport"))
@@ -125,7 +125,7 @@ public class Weeble : Sample
     {
         base.Draw(settings);
 
-        m_context.draw.DrawCircle(m_explosionPosition, m_explosionRadius, B2HexColor.b2_colorAzure);
+        m_draw.DrawCircle(m_explosionPosition, m_explosionRadius, B2HexColor.b2_colorAzure);
 
         // This shows how to get the velocity of a point on a body
         B2Vec2 localPoint = new B2Vec2(0.0f, 2.0f);
@@ -135,7 +135,7 @@ public class Weeble : Sample
         B2Vec2 v2 = b2Body_GetWorldPointVelocity(m_weebleId, worldPoint);
 
         B2Vec2 offset = new B2Vec2(0.05f, 0.0f);
-        m_context.draw.DrawSegment(worldPoint, worldPoint + v1, B2HexColor.b2_colorRed);
-        m_context.draw.DrawSegment(worldPoint + offset, worldPoint + v2 + offset, B2HexColor.b2_colorGreen);
+        m_draw.DrawSegment(worldPoint, worldPoint + v1, B2HexColor.b2_colorRed);
+        m_draw.DrawSegment(worldPoint + offset, worldPoint + v2 + offset, B2HexColor.b2_colorGreen);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
+++ b/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
@@ -56,9 +56,6 @@ public class Mover : Sample
     private readonly B2Vec2 m_elevatorBase = new B2Vec2(112.0f, 10.0f);
     private const float m_elevatorAmplitude = 4.0f;
 
-    private float m_pogoRestLength = 0.5f;
-    private float m_capsuleRadius = 0.4f;
-    private float m_capsuleInteriorLength = 0.5f;
     private float m_jumpSpeed = 10.0f;
     private float m_maxSpeed = 6.0f;
     private float m_minSpeed = 0.1f;
@@ -69,13 +66,10 @@ public class Mover : Sample
     private float m_gravity = 30.0f;
     private float m_pogoHertz = 5.0f;
     private float m_pogoDampingRatio = 0.8f;
-    private float m_stepDownHeight = 0.5f;
 
     private int m_pogoShape = (int)PogoShape.PogoSegment;
     private B2Transform m_transform;
     private B2Vec2 m_velocity;
-    private B2Vec2 m_groundNormal;
-    private B2Vec2 m_nonWalkablePosition;
     private B2Capsule m_capsule;
     private B2BodyId m_elevatorId;
     private B2ShapeId m_ballId;
@@ -86,9 +80,7 @@ public class Mover : Sample
     public int m_totalIterations;
     public float m_pogoVelocity;
     public float m_time;
-    public float m_noWalkTime;
     public bool m_onGround;
-    public bool m_canWalk;
     public bool m_jumpReleased;
     public bool m_lockCamera;
 
@@ -115,14 +107,14 @@ public class Mover : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(20.0f, 9.0f);
-            m_context.camera.m_zoom = 10.0f;
+            m_camera.m_center = new B2Vec2(20.0f, 9.0f);
+            m_camera.m_zoom = 10.0f;
         }
 
         m_context.settings.drawJoints = false;
         m_transform = new B2Transform(new B2Vec2(2.0f, 8.0f), b2Rot_identity);
         m_velocity = new B2Vec2(0.0f, 0.0f);
-        m_capsule = new B2Capsule(new B2Vec2(0.0f, -0.5f * m_capsuleInteriorLength), new B2Vec2(0.0f, 0.5f * m_capsuleInteriorLength), m_capsuleInteriorLength);
+        m_capsule = new B2Capsule(new B2Vec2(0.0f, -0.5f), new B2Vec2(0.0f, 0.5f), 0.3f);
 
         B2BodyId groundId1;
         {
@@ -131,12 +123,11 @@ public class Mover : Sample
             groundId1 = b2CreateBody(m_worldId, ref bodyDef);
 
             const string path =
-                "M -34.395834,201.08333 H 293.68751 v -47.625 h -2.64584 l -10.58333,7.9375 -13.22916,7.9375 -13.24648,5.29167 "
+                "M 2.6458333,201.08333 H 293.68751 v -47.625 h -2.64584 l -10.58333,7.9375 -13.22916,7.9375 -13.24648,5.29167 "
                 + "-31.73269,7.9375 -21.16667,2.64583 -23.8125,10.58333 H 142.875 v -5.29167 h -5.29166 v 5.29167 H 119.0625 v "
                 + "-2.64583 h -2.64583 v -2.64584 h -2.64584 v -2.64583 H 111.125 v -2.64583 H 84.666668 v -2.64583 h -5.291666 v "
-                + "-2.64584 h -5.291667 v -2.64583 H 68.791668 V 174.625 h -5.291666 v -2.64584 H 52.916669 L 39.6875,177.27083 h "
-                + "-5.291667 l -7.937499,5.29167 H 15.875001 l -47.625002,-50.27083 v -26.45834 h -2.645834 l 10e-7,95.25";
-
+                + "-2.64584 h -5.291667 v -2.64583 H 68.791668 V 174.625 h -5.291666 v -2.64584 H 52.916669 L 39.6875,177.27083 H "
+                + "34.395833 L 23.8125,185.20833 H 15.875 L 5.2916669,187.85416 V 153.45833 H 2.6458333 v 47.625";
 
             B2Vec2[] points = new B2Vec2[64];
 
@@ -276,13 +267,9 @@ public class Mover : Sample
             b2CreatePolygonShape(m_elevatorId, ref shapeDef, ref box);
         }
 
-        m_nonWalkablePosition = m_transform.p;
-        m_noWalkTime = 0.0f;
-        m_groundNormal = b2Vec2_zero;
         m_totalIterations = 0;
         m_pogoVelocity = 0.0f;
         m_onGround = false;
-        m_canWalk = false;
         m_jumpReleased = true;
         m_lockCamera = true;
         m_planeCount = 0;
@@ -292,8 +279,6 @@ public class Mover : Sample
     // https://github.com/id-Software/Quake/blob/master/QW/client/pmove.c#L390
     void SolveMove(float timeStep, float throttle)
     {
-        bool walkable = m_groundNormal.Y > 0.71f;
-        
         // Friction
         float speed = b2Length(m_velocity);
         if (speed < m_minSpeed)
@@ -301,7 +286,7 @@ public class Mover : Sample
             m_velocity.X = 0.0f;
             m_velocity.Y = 0.0f;
         }
-        else if ( m_onGround && walkable )
+        else if (m_onGround)
         {
             // Linear damping above stopSpeed and fixed reduction below stopSpeed
             float control = speed < m_stopSpeed ? m_stopSpeed : speed;
@@ -322,37 +307,9 @@ public class Mover : Sample
         }
 
         float noWalkSteer = 0.0f;
-        if ( m_onGround )
+        if (m_onGround)
         {
-            if ( walkable )
-            {
-                m_velocity.Y = 0.0f;
-                noWalkSteer = m_airSteer;
-                m_noWalkTime = 0.0f;
-            }
-            else
-            {
-                if ( m_noWalkTime == 0.0f )
-                {
-                    m_nonWalkablePosition = m_transform.p;
-                }
-
-                m_velocity = m_velocity - b2Dot( m_velocity, m_groundNormal ) * m_groundNormal;
-                // m_noWalkSpeed = m_airSteer * b2MaxFloat( 0.0f, 1.0f - 0.25f * speed / b2MaxFloat(m_stopSpeed, 1.0f) );
-
-                float noWalkDistance = b2Distance( m_transform.p, m_nonWalkablePosition );
-                noWalkSteer = m_airSteer;
-                m_noWalkTime += timeStep;
-                // if ( noWalkDistance / m_noWalkTime < 0.5f * m_airSteer * m_maxSpeed )
-                //{
-                //	noWalkSteer = m_airSteer + 0.5f * m_noWalkTime * ( 1.0f - m_airSteer );
-                //	noWalkSteer = b2ClampFloat( noWalkSteer, m_airSteer, 1.0f );
-                // }
-            }
-        }
-        else
-        {
-            m_noWalkTime = 0.0f;
+            m_velocity.Y = 0.0f;
         }
 
         // Accelerate
@@ -360,18 +317,8 @@ public class Mover : Sample
         float addSpeed = desiredSpeed - currentSpeed;
         if (addSpeed > 0.0f)
         {
-            float steer;
-            if ( m_onGround )
-            {
-                steer = walkable ? 1.0f : noWalkSteer;
-            }
-            else
-            {
-                steer = m_airSteer;
-            }
+            float steer = m_onGround ? 1.0f : m_airSteer;
 
-            DrawTextLine( $"steer = {steer:F2}f" );
-            
             float accelSpeed = steer * m_accelerate * m_maxSpeed * timeStep;
             if (accelSpeed > addSpeed)
             {
@@ -383,19 +330,15 @@ public class Mover : Sample
 
         m_velocity.Y -= m_gravity * timeStep;
 
-        // This ray extension keeps you glued to the ground when walking down slopes.
-        // The extension increases with velocity.
-        float rayExtension = m_stepDownHeight;
-        rayExtension += m_onGround ? b2Length( m_velocity ) * timeStep : 0.0f;
-
-        float rayLength = m_pogoRestLength + m_capsule.radius + rayExtension;
-
-        DrawTextLine( $"extension = {rayExtension:F3}f" );
-        
+        float pogoRestLength = 3.0f * m_capsule.radius;
+        float rayLength = pogoRestLength + m_capsule.radius;
         B2Vec2 origin = b2TransformPoint(ref m_transform, m_capsule.center1);
-        B2Circle circle = new B2Circle(origin, 0.9f * m_capsule.radius);
-        B2Vec2 segmentOffset = new B2Vec2(0.9f * m_capsule.radius, 0.0f);
-        B2Segment segment = new B2Segment(origin - segmentOffset, origin + segmentOffset);
+        B2Circle circle = new B2Circle(origin, 0.5f * m_capsule.radius);
+        B2Vec2 segmentOffset = new B2Vec2(0.75f * m_capsule.radius, 0.0f);
+        B2Segment segment = new B2Segment(
+            origin - segmentOffset,
+            origin + segmentOffset
+        );
 
         B2ShapeProxy proxy = new B2ShapeProxy();
         B2Vec2 translation;
@@ -433,52 +376,49 @@ public class Mover : Sample
         if (castResult.hit == false)
         {
             m_pogoVelocity = 0.0f;
-            m_groundNormal = b2Vec2_zero;
 
             B2Vec2 delta = translation;
-            m_context.draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
+            m_draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
 
             if (m_pogoShape == (int)PogoShape.PogoPoint)
             {
-                m_context.draw.DrawPoint(origin + delta, 10.0f, B2HexColor.b2_colorGray);
+                m_draw.DrawPoint(origin + delta, 10.0f, B2HexColor.b2_colorGray);
             }
             else if (m_pogoShape == (int)PogoShape.PogoCircle)
             {
-                m_context.draw.DrawCircle(origin + delta, circle.radius, B2HexColor.b2_colorGray);
+                m_draw.DrawCircle(origin + delta, circle.radius, B2HexColor.b2_colorGray);
             }
             else
             {
-                m_context.draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorGray);
+                m_draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorGray);
             }
         }
         else
         {
-            m_groundNormal = castResult.normal;
-
-            float pogoCurrentLength = castResult.fraction * rayLength - m_capsuleRadius;
+            float pogoCurrentLength = castResult.fraction * rayLength;
 
             float zeta = m_pogoDampingRatio;
             float hertz = m_pogoHertz;
             float omega = 2.0f * B2_PI * hertz;
             float omegaH = omega * timeStep;
 
-            m_pogoVelocity = ( m_pogoVelocity - omega * omegaH * ( pogoCurrentLength - m_pogoRestLength ) ) /
-                             ( 1.0f + 2.0f * zeta * omegaH + omegaH * omegaH );
+            m_pogoVelocity = (m_pogoVelocity - omega * omegaH * (pogoCurrentLength - pogoRestLength)) /
+                             (1.0f + 2.0f * zeta * omegaH + omegaH * omegaH);
 
             B2Vec2 delta = castResult.fraction * translation;
-            m_context.draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
+            m_draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
 
             if (m_pogoShape == (int)PogoShape.PogoPoint)
             {
-                m_context.draw.DrawPoint(origin + delta, 10.0f, B2HexColor.b2_colorPlum);
+                m_draw.DrawPoint(origin + delta, 10.0f, B2HexColor.b2_colorPlum);
             }
             else if (m_pogoShape == (int)PogoShape.PogoCircle)
             {
-                m_context.draw.DrawCircle(origin + delta, circle.radius, B2HexColor.b2_colorPlum);
+                m_draw.DrawCircle(origin + delta, circle.radius, B2HexColor.b2_colorPlum);
             }
             else
             {
-                m_context.draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorPlum);
+                m_draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorPlum);
             }
 
             b2Body_ApplyForce(castResult.bodyId, new B2Vec2(0.0f, -50.0f), castResult.point, true);
@@ -528,7 +468,7 @@ public class Mover : Sample
     public override void UpdateGui()
     {
         float height = 350.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 25.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(340.0f, height));
 
         ImGui.Begin("Mover", 0);
@@ -609,12 +549,12 @@ public class Mover : Sample
     {
         if (key == Keys.K)
         {
-            B2Vec2 point = b2TransformPoint(ref m_transform, new B2Vec2(0.0f, m_capsule.center1.Y - m_capsuleRadius));
+            B2Vec2 point = b2TransformPoint(ref m_transform, new B2Vec2(0.0f, m_capsule.center1.Y - 3.0f * m_capsule.radius));
             B2Circle circle = new B2Circle(point, 0.5f);
             B2ShapeProxy proxy = b2MakeProxy(circle.center, 1, circle.radius);
             B2QueryFilter filter = new B2QueryFilter(MoverBit, DebrisBit);
             b2World_OverlapShape(m_worldId, ref proxy, filter, Kick, this);
-            m_context.draw.DrawCircle(circle.center, circle.radius, B2HexColor.b2_colorGoldenRod);
+            m_draw.DrawCircle(circle.center, circle.radius, B2HexColor.b2_colorGoldenRod);
         }
 
         base.Keyboard(key);
@@ -663,8 +603,7 @@ public class Mover : Sample
 
             if (InputAction.Press == GetKey(Keys.Space))
             {
-                bool walkable = m_groundNormal.Y > 0.71f;
-                if ( m_onGround == true && walkable && m_jumpReleased )
+                if (m_onGround == true && m_jumpReleased)
                 {
                     m_velocity.Y = m_jumpSpeed;
                     m_onGround = false;
@@ -690,8 +629,8 @@ public class Mover : Sample
             B2Plane plane = m_planes[i].plane;
             B2Vec2 p1 = m_transform.p + (plane.offset - m_capsule.radius) * plane.normal;
             B2Vec2 p2 = p1 + 0.1f * plane.normal;
-            m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorYellow);
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorYellow);
+            m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorYellow);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorYellow);
         }
 
         {
@@ -699,8 +638,8 @@ public class Mover : Sample
             B2Vec2 p2 = b2TransformPoint(ref m_transform, m_capsule.center2);
 
             B2HexColor color = m_onGround ? B2HexColor.b2_colorOrange : B2HexColor.b2_colorAquamarine;
-            m_context.draw.DrawSolidCapsule(p1, p2, m_capsule.radius, color);
-            m_context.draw.DrawSegment(m_transform.p, m_transform.p + m_velocity, B2HexColor.b2_colorPurple);
+            m_draw.DrawSolidCapsule(p1, p2, m_capsule.radius, color);
+            m_draw.DrawSegment(m_transform.p, m_transform.p + m_velocity, B2HexColor.b2_colorPurple);
         }
 
         B2Vec2 p = m_transform.p;
@@ -710,7 +649,7 @@ public class Mover : Sample
 
         if (m_lockCamera)
         {
-            m_context.camera.m_center.X = m_transform.p.X;
+            m_camera.m_center.X = m_transform.p.X;
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
@@ -79,8 +79,8 @@ public class CastWorld : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.0f, 14.0f);
-            m_context.camera.m_zoom = 25.0f * 0.75f;
+            m_camera.m_center = new B2Vec2(2.0f, 14.0f);
+            m_camera.m_zoom = 25.0f * 0.75f;
         }
 
         // Ground body
@@ -289,7 +289,7 @@ public class CastWorld : Sample
         base.UpdateGui();
 
         float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Ray-cast World", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -386,14 +386,14 @@ public class CastWorld : Sample
             if (result.hit == true)
             {
                 B2Vec2 c = b2MulAdd(m_rayStart, result.fraction, rayTranslation);
-                m_context.draw.DrawPoint(result.point, 5.0f, color1);
-                m_context.draw.DrawSegment(m_rayStart, c, color2);
+                m_draw.DrawPoint(result.point, 5.0f, color1);
+                m_draw.DrawSegment(m_rayStart, c, color2);
                 B2Vec2 head = b2MulAdd(result.point, 0.5f, result.normal);
-                m_context.draw.DrawSegment(result.point, head, color3);
+                m_draw.DrawSegment(result.point, head, color3);
             }
             else
             {
-                m_context.draw.DrawSegment(m_rayStart, m_rayEnd, color2);
+                m_draw.DrawSegment(m_rayStart, m_rayEnd, color2);
             }
         }
         else
@@ -451,53 +451,53 @@ public class CastWorld : Sample
                     B2Vec2 c = b2MulAdd(m_rayStart, context.fractions[i], rayTranslation);
                     B2Vec2 p = context.points[i];
                     B2Vec2 n = context.normals[i];
-                    m_context.draw.DrawPoint(p, 5.0f, colors[i]);
-                    m_context.draw.DrawSegment(m_rayStart, c, color2);
+                    m_draw.DrawPoint(p, 5.0f, colors[i]);
+                    m_draw.DrawSegment(m_rayStart, c, color2);
                     B2Vec2 head = b2MulAdd(p, 0.5f, n);
-                    m_context.draw.DrawSegment(p, head, color3);
+                    m_draw.DrawSegment(p, head, color3);
 
                     B2Vec2 t = b2MulSV(context.fractions[i], rayTranslation);
                     B2Transform shiftedTransform = new B2Transform(t, b2Rot_identity);
 
                     if (m_castType == CastType.e_circleCast)
                     {
-                        m_context.draw.DrawSolidCircle(ref shiftedTransform, circle.center, m_castRadius, B2HexColor.b2_colorYellow);
+                        m_draw.DrawSolidCircle(ref shiftedTransform, circle.center, m_castRadius, B2HexColor.b2_colorYellow);
                     }
                     else if (m_castType == CastType.e_capsuleCast)
                     {
                         B2Vec2 p1 = capsule.center1 + t;
                         B2Vec2 p2 = capsule.center2 + t;
-                        m_context.draw.DrawSolidCapsule(p1, p2, m_castRadius, B2HexColor.b2_colorYellow);
+                        m_draw.DrawSolidCapsule(p1, p2, m_castRadius, B2HexColor.b2_colorYellow);
                     }
                     else if (m_castType == CastType.e_polygonCast)
                     {
-                        m_context.draw.DrawSolidPolygon(ref shiftedTransform, box.vertices.AsSpan(), box.count, box.radius, B2HexColor.b2_colorYellow);
+                        m_draw.DrawSolidPolygon(ref shiftedTransform, box.vertices.AsSpan(), box.count, box.radius, B2HexColor.b2_colorYellow);
                     }
                 }
             }
             else
             {
                 B2Transform shiftedTransform = new B2Transform(b2Add(transform.p, rayTranslation), transform.q);
-                m_context.draw.DrawSegment(m_rayStart, m_rayEnd, color2);
+                m_draw.DrawSegment(m_rayStart, m_rayEnd, color2);
 
                 if (m_castType == CastType.e_circleCast)
                 {
-                    m_context.draw.DrawSolidCircle(ref shiftedTransform, b2Vec2_zero, m_castRadius, B2HexColor.b2_colorGray);
+                    m_draw.DrawSolidCircle(ref shiftedTransform, b2Vec2_zero, m_castRadius, B2HexColor.b2_colorGray);
                 }
                 else if (m_castType == CastType.e_capsuleCast)
                 {
                     B2Vec2 p1 = b2Add(b2TransformPoint(ref transform, capsule.center1), rayTranslation);
                     B2Vec2 p2 = b2Add(b2TransformPoint(ref transform, capsule.center2), rayTranslation);
-                    m_context.draw.DrawSolidCapsule(p1, p2, m_castRadius, B2HexColor.b2_colorYellow);
+                    m_draw.DrawSolidCapsule(p1, p2, m_castRadius, B2HexColor.b2_colorYellow);
                 }
                 else if (m_castType == CastType.e_polygonCast)
                 {
-                    m_context.draw.DrawSolidPolygon(ref shiftedTransform, box.vertices.AsSpan(), box.count, box.radius, B2HexColor.b2_colorYellow);
+                    m_draw.DrawSolidPolygon(ref shiftedTransform, box.vertices.AsSpan(), box.count, box.radius, B2HexColor.b2_colorYellow);
                 }
             }
         }
 
-        m_context.draw.DrawPoint(m_rayStart, 5.0f, B2HexColor.b2_colorGreen);
+        m_draw.DrawPoint(m_rayStart, 5.0f, B2HexColor.b2_colorGreen);
     }
 
     public override void Draw(Settings settings)
@@ -548,7 +548,7 @@ public class CastWorld : Sample
         {
             B2Vec2 p = b2Body_GetPosition(m_bodyIds[m_ignoreIndex]);
             p.X -= 0.2f;
-            m_context.draw.DrawString(p, "ign");
+            m_draw.DrawString(p, "ign");
         }
     }
 

--- a/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
@@ -77,8 +77,8 @@ public class DynamicTree : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(500.0f, 500.0f);
-            m_context.camera.m_zoom = 25.0f * 21.0f;
+            m_camera.m_center = new B2Vec2(500.0f, 500.0f);
+            m_camera.m_zoom = 25.0f * 21.0f;
         }
 
         m_fill = 0.25f;
@@ -192,7 +192,7 @@ public class DynamicTree : Sample
         base.UpdateGui();
 
         float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Dynamic Tree", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -315,11 +315,11 @@ public class DynamicTree : Sample
 
             if (p.queryStamp == m_timeStamp || p.rayStamp == m_timeStamp)
             {
-                m_context.draw.DrawAABB(p.box, qc);
+                m_draw.DrawAABB(p.box, qc);
             }
             else
             {
-                m_context.draw.DrawAABB(p.box, c);
+                m_draw.DrawAABB(p.box, c);
             }
 
             float moveTest = RandomFloatRange(0.0f, 1.0f);
@@ -429,7 +429,7 @@ public class DynamicTree : Sample
 
             b2DynamicTree_Query(m_tree, box, B2_DEFAULT_MASK_BITS, QueryCallback, ref dynamicTreeContext);
 
-            m_context.draw.DrawAABB(box, B2HexColor.b2_colorWhite);
+            m_draw.DrawAABB(box, B2HexColor.b2_colorWhite);
         }
 
         // m_startPoint = {-1.0f, 0.5f};
@@ -443,9 +443,9 @@ public class DynamicTree : Sample
             B2RayCastInput input = new B2RayCastInput(m_startPoint, b2Sub(m_endPoint, m_startPoint), 1.0f);
             B2TreeStats result = b2DynamicTree_RayCast(m_tree, ref input, B2_DEFAULT_MASK_BITS, RayCallback, ref dynamicTreeContext);
 
-            m_context.draw.DrawSegment(m_startPoint, m_endPoint, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(m_startPoint, 5.0f, B2HexColor.b2_colorGreen);
-            m_context.draw.DrawPoint(m_endPoint, 5.0f, B2HexColor.b2_colorRed);
+            m_draw.DrawSegment(m_startPoint, m_endPoint, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(m_startPoint, 5.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(m_endPoint, 5.0f, B2HexColor.b2_colorRed);
 
             DrawTextLine($"node visits = {result.nodeVisits}, leaf visits = {result.leafVisits}");
             

--- a/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
@@ -53,8 +53,8 @@ public class Manifold : Sample
         if (m_context.settings.restart == false)
         {
             // m_context.g_camera.m_center = {1.8f, 15.0f};
-            m_context.camera.m_center = new B2Vec2(1.8f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 0.45f;
+            m_camera.m_center = new B2Vec2(1.8f, 0.0f);
+            m_camera.m_zoom = 25.0f * 0.45f;
         }
 
         m_smgroxCache1 = b2_emptySimplexCache;
@@ -90,7 +90,7 @@ public class Manifold : Sample
         base.UpdateGui();
 
         float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(340.0f, height));
 
         ImGui.Begin("Manifold", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -180,7 +180,7 @@ public class Manifold : Sample
         if (m_showCount)
         {
             B2Vec2 p = 0.5f * (origin1 + origin2);
-            m_context.draw.DrawString(p, $"{manifold.pointCount}");
+            m_draw.DrawString(p, $"{manifold.pointCount}");
         }
 
         for (int i = 0; i < manifold.pointCount; ++i)
@@ -189,16 +189,16 @@ public class Manifold : Sample
 
             B2Vec2 p1 = mp.point;
             B2Vec2 p2 = b2MulAdd(p1, 0.5f, manifold.normal);
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorViolet);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorViolet);
 
             if (m_showAnchors)
             {
-                m_context.draw.DrawPoint(b2Add(origin1, mp.anchorA), 5.0f, B2HexColor.b2_colorRed);
-                m_context.draw.DrawPoint(b2Add(origin2, mp.anchorB), 5.0f, B2HexColor.b2_colorGreen);
+                m_draw.DrawPoint(b2Add(origin1, mp.anchorA), 5.0f, B2HexColor.b2_colorRed);
+                m_draw.DrawPoint(b2Add(origin2, mp.anchorB), 5.0f, B2HexColor.b2_colorGreen);
             }
             else
             {
-                m_context.draw.DrawPoint(p1, 10.0f, B2HexColor.b2_colorBlue);
+                m_draw.DrawPoint(p1, 10.0f, B2HexColor.b2_colorBlue);
             }
 
             if (m_showIds)
@@ -206,13 +206,13 @@ public class Manifold : Sample
                 // uint indexA = mp.id >> 8;
                 // uint indexB = 0xFF & mp.id;
                 B2Vec2 p = new B2Vec2(p1.X + 0.05f, p1.Y - 0.02f);
-                m_context.draw.DrawString(p, $"0x{mp.id:X4}");
+                m_draw.DrawString(p, $"0x{mp.id:X4}");
             }
 
             if (m_showSeparation)
             {
                 B2Vec2 p = new B2Vec2(p1.X + 0.05f, p1.Y + 0.03f);
-                m_context.draw.DrawString(p, $"{mp.separation:F3}");
+                m_draw.DrawString(p, $"{mp.separation:F3}");
             }
         }
     }
@@ -244,8 +244,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollideCircles(ref circle1, transform1, ref circle2, transform2);
 
-            m_context.draw.DrawSolidCircle(ref transform1, circle1.center, circle1.radius, color1);
-            m_context.draw.DrawSolidCircle(ref transform2, circle2.center, circle2.radius, color2);
+            m_draw.DrawSolidCircle(ref transform1, circle1.center, circle1.radius, color1);
+            m_draw.DrawSolidCircle(ref transform2, circle2.center, circle2.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -264,9 +264,9 @@ public class Manifold : Sample
 
             B2Vec2 v1 = b2TransformPoint(ref transform1, capsule.center1);
             B2Vec2 v2 = b2TransformPoint(ref transform1, capsule.center2);
-            m_context.draw.DrawSolidCapsule(v1, v2, capsule.radius, color1);
+            m_draw.DrawSolidCapsule(v1, v2, capsule.radius, color1);
 
-            m_context.draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
+            m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -285,9 +285,9 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_context.draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawSegment(p1, p2, color1);
 
-            m_context.draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
+            m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -305,8 +305,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygonAndCircle(ref box, transform1, ref circle, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, m_round, color1);
-            m_context.draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, m_round, color1);
+            m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -325,11 +325,11 @@ public class Manifold : Sample
 
             B2Vec2 v1 = b2TransformPoint(ref transform1, capsule1.center1);
             B2Vec2 v2 = b2TransformPoint(ref transform1, capsule1.center2);
-            m_context.draw.DrawSolidCapsule(v1, v2, capsule1.radius, color1);
+            m_draw.DrawSolidCapsule(v1, v2, capsule1.radius, color1);
 
             v1 = b2TransformPoint(ref transform2, capsule2.center1);
             v2 = b2TransformPoint(ref transform2, capsule2.center2);
-            m_context.draw.DrawSolidCapsule(v1, v2, capsule2.radius, color2);
+            m_draw.DrawSolidCapsule(v1, v2, capsule2.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -346,11 +346,11 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygonAndCapsule(ref box, transform1, ref capsule, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, box.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, box.radius, color1);
 
             B2Vec2 v1 = b2TransformPoint(ref transform2, capsule.center1);
             B2Vec2 v2 = b2TransformPoint(ref transform2, capsule.center2);
-            m_context.draw.DrawSolidCapsule(v1, v2, capsule.radius, color2);
+            m_draw.DrawSolidCapsule(v1, v2, capsule.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -369,11 +369,11 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_context.draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawSegment(p1, p2, color1);
 
             p1 = b2TransformPoint(ref transform2, capsule.center1);
             p2 = b2TransformPoint(ref transform2, capsule.center2);
-            m_context.draw.DrawSolidCapsule(p1, p2, capsule.radius, color2);
+            m_draw.DrawSolidCapsule(p1, p2, capsule.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -394,8 +394,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref box1, transform1, ref box, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box1.vertices.AsSpan(), box1.count, box1.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, box.vertices.AsSpan(), box.count, box.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform1, box1.vertices.AsSpan(), box1.count, box1.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform2, box.vertices.AsSpan(), box.count, box.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -413,8 +413,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref box1, transform1, ref box, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box1.vertices.AsSpan(), box1.count, box1.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, box.vertices.AsSpan(), box.count, box.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform1, box1.vertices.AsSpan(), box1.count, box1.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform2, box.vertices.AsSpan(), box.count, box.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -433,8 +433,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref box, transform1, ref rox, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, box.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, box.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -453,8 +453,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref rox, transform1, ref rox, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, rox.vertices.AsSpan(), rox.count, rox.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform1, rox.vertices.AsSpan(), rox.count, rox.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -475,8 +475,8 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_context.draw.DrawSegment(p1, p2, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
+            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -494,10 +494,10 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref wox, transform1, ref wox, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, wox.vertices.AsSpan(), wox.count, wox.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform1, wox.vertices.AsSpan(), wox.count, 0.0f, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, wox.vertices.AsSpan(), wox.count, wox.radius, color2);
-            m_context.draw.DrawSolidPolygon(ref transform2, wox.vertices.AsSpan(), wox.count, 0.0f, color2);
+            m_draw.DrawSolidPolygon(ref transform1, wox.vertices.AsSpan(), wox.count, wox.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform1, wox.vertices.AsSpan(), wox.count, 0.0f, color1);
+            m_draw.DrawSolidPolygon(ref transform2, wox.vertices.AsSpan(), wox.count, wox.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform2, wox.vertices.AsSpan(), wox.count, 0.0f, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -521,10 +521,10 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref w1, transform1, ref w2, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, w1.vertices.AsSpan(), w1.count, w1.radius, color1);
-            m_context.draw.DrawSolidPolygon(ref transform1, w1.vertices.AsSpan(), w1.count, 0.0f, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, w2.vertices.AsSpan(), w2.count, w2.radius, color2);
-            m_context.draw.DrawSolidPolygon(ref transform2, w2.vertices.AsSpan(), w2.count, 0.0f, color2);
+            m_draw.DrawSolidPolygon(ref transform1, w1.vertices.AsSpan(), w1.count, w1.radius, color1);
+            m_draw.DrawSolidPolygon(ref transform1, w1.vertices.AsSpan(), w1.count, 0.0f, color1);
+            m_draw.DrawSolidPolygon(ref transform2, w2.vertices.AsSpan(), w2.count, w2.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform2, w2.vertices.AsSpan(), w2.count, 0.0f, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -546,8 +546,8 @@ public class Manifold : Sample
 
             B2Manifold m = b2CollidePolygons(ref box, transform1, ref tri, transform2);
 
-            m_context.draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, 0.0f, color1);
-            m_context.draw.DrawSolidPolygon(ref transform2, tri.vertices.AsSpan(), tri.count, 0.0f, color2);
+            m_draw.DrawSolidPolygon(ref transform1, box.vertices.AsSpan(), box.count, 0.0f, color1);
+            m_draw.DrawSolidPolygon(ref transform2, tri.vertices.AsSpan(), tri.count, 0.0f, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -573,10 +573,10 @@ public class Manifold : Sample
             B2Vec2 g2 = b2TransformPoint(ref transform1, segment.ghost2);
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.segment.point2);
-            m_context.draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-            m_context.draw.DrawSegment(p1, p2, color1);
-            m_context.draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
-            m_context.draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
+            m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
+            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+            m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
 
@@ -616,24 +616,24 @@ public class Manifold : Sample
                 B2Vec2 g2 = b2TransformPoint(ref transform1, segment1.ghost2);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment1.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment1.segment.point2);
-                m_context.draw.DrawSegment(p1, p2, color1);
-                m_context.draw.DrawPoint(p1, 4.0f, color1);
-                m_context.draw.DrawPoint(p2, 4.0f, color1);
-                m_context.draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawPoint(p1, 4.0f, color1);
+                m_draw.DrawPoint(p2, 4.0f, color1);
+                m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
             }
 
             {
                 B2Vec2 g1 = b2TransformPoint(ref transform1, segment2.ghost1);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment2.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment2.segment.point2);
-                m_context.draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-                m_context.draw.DrawSegment(p1, p2, color1);
-                m_context.draw.DrawPoint(p1, 4.0f, color1);
-                m_context.draw.DrawPoint(p2, 4.0f, color1);
+                m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
+                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawPoint(p1, 4.0f, color1);
+                m_draw.DrawPoint(p2, 4.0f, color1);
             }
 
-            m_context.draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
-            m_context.draw.DrawPoint(b2TransformPoint(ref transform2, rox.centroid), 5.0f, B2HexColor.b2_colorGainsboro);
+            m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
+            m_draw.DrawPoint(b2TransformPoint(ref transform2, rox.centroid), 5.0f, B2HexColor.b2_colorGainsboro);
 
             DrawManifold(ref m1, transform1.p, transform2.p);
             DrawManifold(ref m2, transform1.p, transform2.p);
@@ -672,29 +672,29 @@ public class Manifold : Sample
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment1.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment1.segment.point2);
                 // m_context.g_draw.DrawSegment(g1, p1, b2HexColor.b2_colorLightGray);
-                m_context.draw.DrawSegment(p1, p2, color1);
-                m_context.draw.DrawPoint(p1, 4.0f, color1);
-                m_context.draw.DrawPoint(p2, 4.0f, color1);
-                m_context.draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawPoint(p1, 4.0f, color1);
+                m_draw.DrawPoint(p2, 4.0f, color1);
+                m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
             }
 
             {
                 B2Vec2 g1 = b2TransformPoint(ref transform1, segment2.ghost1);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment2.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment2.segment.point2);
-                m_context.draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-                m_context.draw.DrawSegment(p1, p2, color1);
-                m_context.draw.DrawPoint(p1, 4.0f, color1);
-                m_context.draw.DrawPoint(p2, 4.0f, color1);
+                m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
+                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawPoint(p1, 4.0f, color1);
+                m_draw.DrawPoint(p2, 4.0f, color1);
                 // m_context.g_draw.DrawSegment(p2, g2, b2HexColor.b2_colorLightGray);
             }
 
             {
                 B2Vec2 p1 = b2TransformPoint(ref transform2, capsule.center1);
                 B2Vec2 p2 = b2TransformPoint(ref transform2, capsule.center2);
-                m_context.draw.DrawSolidCapsule(p1, p2, capsule.radius, color2);
+                m_draw.DrawSolidCapsule(p1, p2, capsule.radius, color2);
 
-                m_context.draw.DrawPoint(b2Lerp(p1, p2, 0.5f), 5.0f, B2HexColor.b2_colorGainsboro);
+                m_draw.DrawPoint(b2Lerp(p1, p2, 0.5f), 5.0f, B2HexColor.b2_colorGainsboro);
             }
 
             DrawManifold(ref m1, transform1.p, transform2.p);

--- a/src/Box2D.NET.Samples/Samples/Collisions/OverlapWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/OverlapWorld.cs
@@ -89,8 +89,8 @@ public class OverlapWorld : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.7f;
+            m_camera.m_center = new B2Vec2(0.0f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.7f;
         }
 
         m_userData = new ShapeUserData[e_maxCount];
@@ -270,7 +270,7 @@ public class OverlapWorld : Sample
         base.UpdateGui();
 
         float height = 330.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Overlap World", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -347,7 +347,7 @@ public class OverlapWorld : Sample
             circle.radius = 1.0f;
             proxy = b2MakeProxy(circle.center, 1, circle.radius);
             B2Transform identity = b2Transform_identity;
-            m_context.draw.DrawSolidCircle(ref identity, circle.center, circle.radius, B2HexColor.b2_colorWhite);
+            m_draw.DrawSolidCircle(ref identity, circle.center, circle.radius, B2HexColor.b2_colorWhite);
         }
         else if (m_shapeType == e_capsuleShape)
         {
@@ -356,13 +356,13 @@ public class OverlapWorld : Sample
             capsule.center2 = b2TransformPoint(ref transform, new B2Vec2(1.0f, 0.0f));
             capsule.radius = 0.5f;
             proxy = b2MakeProxy(capsule.center1, capsule.center2, 2, capsule.radius);
-            m_context.draw.DrawSolidCapsule(capsule.center1, capsule.center2, capsule.radius, B2HexColor.b2_colorWhite);
+            m_draw.DrawSolidCapsule(capsule.center1, capsule.center2, capsule.radius, B2HexColor.b2_colorWhite);
         }
         else if (m_shapeType == e_boxShape)
         {
             B2Polygon box = b2MakeOffsetBox(2.0f, 0.5f, transform.p, transform.q);
             proxy = b2MakeProxy(box.vertices.AsSpan(), box.count, box.radius);
-            m_context.draw.DrawPolygon(box.vertices.AsSpan(), box.count, B2HexColor.b2_colorWhite);
+            m_draw.DrawPolygon(box.vertices.AsSpan(), box.count, B2HexColor.b2_colorWhite);
         }
 
         b2World_OverlapShape(m_worldId, ref proxy, b2DefaultQueryFilter(), OverlapResultFcn, this);
@@ -399,7 +399,7 @@ public class OverlapWorld : Sample
         {
             B2Vec2 p = b2Body_GetPosition(m_bodyIds[m_ignoreIndex]);
             p.X -= 0.2f;
-            m_context.draw.DrawString(p, "skip");
+            m_draw.DrawString(p, "skip");
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
@@ -47,8 +47,8 @@ public class RayCast : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 20.0f);
-            m_context.camera.m_zoom = 17.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 20.0f);
+            m_camera.m_zoom = 17.5f;
         }
 
         m_circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 2.0f);
@@ -83,7 +83,7 @@ public class RayCast : Sample
         base.UpdateGui();
 
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Ray-cast", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -183,12 +183,12 @@ public class RayCast : Sample
         if (output.hit)
         {
             B2Vec2 p = b2MulAdd(p1, output.fraction, d);
-            m_context.draw.DrawSegment(p1, p, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
-            m_context.draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawSegment(p1, p, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
 
             B2Vec2 n = b2MulAdd(p, 1.0f, output.normal);
-            m_context.draw.DrawSegment(p, n, B2HexColor.b2_colorViolet);
+            m_draw.DrawSegment(p, n, B2HexColor.b2_colorViolet);
 
             // if (m_rayRadius > 0.0f)
             //{
@@ -199,14 +199,14 @@ public class RayCast : Sample
             if (m_showFraction)
             {
                 B2Vec2 ps = new B2Vec2(p.X + 0.05f, p.Y - 0.02f);
-                m_context.draw.DrawString(ps, $"{output.fraction:F2}");
+                m_draw.DrawString(ps, $"{output.fraction:F2}");
             }
         }
         else
         {
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
-            m_context.draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
 
             // if (m_rayRadius > 0.0f)
             //{
@@ -229,7 +229,7 @@ public class RayCast : Sample
         // circle
         {
             B2Transform transform = new B2Transform(b2Add(m_transform.p, offset), m_transform.q);
-            m_context.draw.DrawSolidCircle(ref transform, m_circle.center, m_circle.radius, color1);
+            m_draw.DrawSolidCircle(ref transform, m_circle.center, m_circle.radius, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
@@ -252,7 +252,7 @@ public class RayCast : Sample
             B2Transform transform = new B2Transform(b2Add(m_transform.p, offset), m_transform.q);
             B2Vec2 v1 = b2TransformPoint(ref transform, m_capsule.center1);
             B2Vec2 v2 = b2TransformPoint(ref transform, m_capsule.center2);
-            m_context.draw.DrawSolidCapsule(v1, v2, m_capsule.radius, color1);
+            m_draw.DrawSolidCapsule(v1, v2, m_capsule.radius, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
@@ -273,7 +273,7 @@ public class RayCast : Sample
         // box
         {
             B2Transform transform = new B2Transform(b2Add(m_transform.p, offset), m_transform.q);
-            m_context.draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, 0.0f, color1);
+            m_draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, 0.0f, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
@@ -294,7 +294,7 @@ public class RayCast : Sample
         // triangle
         {
             B2Transform transform = new B2Transform(b2Add(m_transform.p, offset), m_transform.q);
-            m_context.draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, 0.0f, color1);
+            m_draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, 0.0f, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
@@ -318,7 +318,7 @@ public class RayCast : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform, m_segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform, m_segment.point2);
-            m_context.draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawSegment(p1, p2, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
@@ -67,8 +67,8 @@ public class ShapeCast : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(-0.0f, 0.25f);
-            m_context.camera.m_zoom = 3.0f;
+            m_camera.m_center = new B2Vec2(-0.0f, 0.25f);
+            m_camera.m_zoom = 3.0f;
         }
 
         m_point = b2Vec2_zero;
@@ -189,11 +189,11 @@ public class ShapeCast : Sample
                 B2Vec2 p = b2TransformPoint(ref transform, m_point);
                 if (radius > 0.0f)
                 {
-                    m_context.draw.DrawSolidCircle(ref transform, m_point, radius, color);
+                    m_draw.DrawSolidCircle(ref transform, m_point, radius, color);
                 }
                 else
                 {
-                    m_context.draw.DrawPoint(p, 5.0f, color);
+                    m_draw.DrawPoint(p, 5.0f, color);
                 }
             }
                 break;
@@ -205,21 +205,21 @@ public class ShapeCast : Sample
 
                 if (radius > 0.0f)
                 {
-                    m_context.draw.DrawSolidCapsule(p1, p2, radius, color);
+                    m_draw.DrawSolidCapsule(p1, p2, radius, color);
                 }
                 else
                 {
-                    m_context.draw.DrawSegment(p1, p2, color);
+                    m_draw.DrawSegment(p1, p2, color);
                 }
             }
                 break;
 
             case ShapeType.e_triangle:
-                m_context.draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, radius, color);
+                m_draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, radius, color);
                 break;
 
             case ShapeType.e_box:
-                m_context.draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, radius, color);
+                m_draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, radius, color);
                 break;
 
             default:
@@ -290,7 +290,7 @@ public class ShapeCast : Sample
     public override void UpdateGui()
     {
         float height = 300.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Distance", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -386,8 +386,8 @@ public class ShapeCast : Sample
         if (output.hit)
         {
             DrawShape(m_typeB, inputTransform, m_radiusB, B2HexColor.b2_colorPlum);
-            m_context.draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawSegment(output.point, output.point + 0.5f * output.normal, B2HexColor.b2_colorYellow);
+            m_draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawSegment(output.point, output.point + 0.5f * output.normal, B2HexColor.b2_colorYellow);
         }
 
         if (m_showIndices)
@@ -395,13 +395,13 @@ public class ShapeCast : Sample
             for (int i = 0; i < m_proxyA.count; ++i)
             {
                 B2Vec2 p = m_proxyA.points[i];
-                m_context.draw.DrawString(p, $" {i}");
+                m_draw.DrawString(p, $" {i}");
             }
 
             for (int i = 0; i < m_proxyB.count; ++i)
             {
                 B2Vec2 p = b2TransformPoint(ref m_transform, m_proxyB.points[i]);
-                m_context.draw.DrawString(p, $" {i}");
+                m_draw.DrawString(p, $" {i}");
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
@@ -79,8 +79,8 @@ public class ShapeDistance : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 3.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 3.0f;
         }
 
         m_point = b2Vec2_zero;
@@ -172,11 +172,11 @@ public class ShapeDistance : Sample
                 B2Vec2 p = b2TransformPoint(ref transform, m_point);
                 if (radius > 0.0f)
                 {
-                    m_context.draw.DrawSolidCircle(ref transform, m_point, radius, color);
+                    m_draw.DrawSolidCircle(ref transform, m_point, radius, color);
                 }
                 else
                 {
-                    m_context.draw.DrawPoint(p, 5.0f, color);
+                    m_draw.DrawPoint(p, 5.0f, color);
                 }
             }
                 break;
@@ -188,21 +188,21 @@ public class ShapeDistance : Sample
 
                 if (radius > 0.0f)
                 {
-                    m_context.draw.DrawSolidCapsule(p1, p2, radius, color);
+                    m_draw.DrawSolidCapsule(p1, p2, radius, color);
                 }
                 else
                 {
-                    m_context.draw.DrawSegment(p1, p2, color);
+                    m_draw.DrawSegment(p1, p2, color);
                 }
             }
                 break;
 
             case ShapeType.e_triangle:
-                m_context.draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, radius, color);
+                m_draw.DrawSolidPolygon(ref transform, m_triangle.vertices.AsSpan(), m_triangle.count, radius, color);
                 break;
 
             case ShapeType.e_box:
-                m_context.draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, radius, color);
+                m_draw.DrawSolidPolygon(ref transform, m_box.vertices.AsSpan(), m_box.count, radius, color);
                 break;
 
             default:
@@ -216,7 +216,7 @@ public class ShapeDistance : Sample
         base.UpdateGui();
 
         float height = 310.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Distance", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -402,9 +402,9 @@ public class ShapeDistance : Sample
                 B2Vec2 pointB = new B2Vec2();
                 ComputeSimplexWitnessPoints(ref pointA, ref pointB, ref simplex);
 
-                m_context.draw.DrawSegment(pointA, pointB, B2HexColor.b2_colorWhite);
-                m_context.draw.DrawPoint(pointA, 10.0f, B2HexColor.b2_colorWhite);
-                m_context.draw.DrawPoint(pointB, 10.0f, B2HexColor.b2_colorWhite);
+                m_draw.DrawSegment(pointA, pointB, B2HexColor.b2_colorWhite);
+                m_draw.DrawPoint(pointA, 10.0f, B2HexColor.b2_colorWhite);
+                m_draw.DrawPoint(pointB, 10.0f, B2HexColor.b2_colorWhite);
             }
 
             B2HexColor[] colors = new B2HexColor[3] { B2HexColor.b2_colorRed, B2HexColor.b2_colorGreen, B2HexColor.b2_colorBlue };
@@ -412,17 +412,17 @@ public class ShapeDistance : Sample
             for (int i = 0; i < simplex.count; ++i)
             {
                 ref B2SimplexVertex vertex = ref vertices[i];
-                m_context.draw.DrawPoint(vertex.wA, 10.0f, colors[i]);
-                m_context.draw.DrawPoint(vertex.wB, 10.0f, colors[i]);
+                m_draw.DrawPoint(vertex.wA, 10.0f, colors[i]);
+                m_draw.DrawPoint(vertex.wB, 10.0f, colors[i]);
             }
         }
         else
         {
-            m_context.draw.DrawSegment(_outputPointA, _outputPointB, B2HexColor.b2_colorDimGray);
-            m_context.draw.DrawPoint(_outputPointA, 10.0f, B2HexColor.b2_colorWhite);
-            m_context.draw.DrawPoint(_outputPointB, 10.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawSegment(_outputPointA, _outputPointB, B2HexColor.b2_colorDimGray);
+            m_draw.DrawPoint(_outputPointA, 10.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(_outputPointB, 10.0f, B2HexColor.b2_colorWhite);
             
-            m_context.draw.DrawSegment( _outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow );
+            m_draw.DrawSegment( _outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow );
         }
 
         if (m_showIndices)
@@ -430,13 +430,13 @@ public class ShapeDistance : Sample
             for (int i = 0; i < m_proxyA.count; ++i)
             {
                 B2Vec2 p = m_proxyA.points[i];
-                m_context.draw.DrawString(p, $" {i}");
+                m_draw.DrawString(p, $" {i}");
             }
 
             for (int i = 0; i < m_proxyB.count; ++i)
             {
                 B2Vec2 p = b2TransformPoint(ref m_transform, m_proxyB.points[i]);
-                m_context.draw.DrawString(p, $" {i}");
+                m_draw.DrawString(p, $" {i}");
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
@@ -49,8 +49,8 @@ public class SmoothManifold : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.0f, 20.0f);
-            m_context.camera.m_zoom = 21.0f;
+            m_camera.m_center = new B2Vec2(2.0f, 20.0f);
+            m_camera.m_zoom = 21.0f;
         }
 
         m_shapeType = ShapeType.e_boxShape;
@@ -137,7 +137,7 @@ public class SmoothManifold : Sample
         base.UpdateGui();
         
         float height = 290.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Smooth Manifold", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -229,15 +229,15 @@ public class SmoothManifold : Sample
 
             B2Vec2 p1 = mp.point;
             B2Vec2 p2 = b2MulAdd(p1, 0.5f, manifold.normal);
-            m_context.draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
 
             if (m_showAnchors)
             {
-                m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+                m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
             }
             else
             {
-                m_context.draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
+                m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
             }
 
             if (m_showIds)
@@ -245,13 +245,13 @@ public class SmoothManifold : Sample
                 // uint indexA = mp.id >> 8;
                 // uint indexB = 0xFF & mp.id;
                 B2Vec2 p = new B2Vec2(p1.X + 0.05f, p1.Y - 0.02f);
-                m_context.draw.DrawString(p, $"0x{mp.id:X4}");
+                m_draw.DrawString(p, $"0x{mp.id:X4}");
             }
 
             if (m_showSeparation)
             {
                 B2Vec2 p = new B2Vec2(p1.X + 0.05f, p1.Y + 0.03f);
-                m_context.draw.DrawString(p, $"{mp.separation:F3}");
+                m_draw.DrawString(p, $"{mp.separation:F3}");
             }
         }
     }
@@ -269,15 +269,15 @@ public class SmoothManifold : Sample
             ref readonly B2ChainSegment segment = ref m_segments[i];
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.segment.point2);
-            m_context.draw.DrawSegment(p1, p2, color1);
-            m_context.draw.DrawPoint(p1, 4.0f, color1);
+            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawPoint(p1, 4.0f, color1);
         }
 
         // chain-segment vs circle
         if (m_shapeType == ShapeType.e_circleShape)
         {
             B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.5f);
-            m_context.draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
+            m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             for (int i = 0; i < m_count; ++i)
             {
@@ -290,7 +290,7 @@ public class SmoothManifold : Sample
         {
             float h = 0.5f - m_round;
             B2Polygon rox = b2MakeRoundedBox(h, h, m_round);
-            m_context.draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
+            m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
 
             for (int i = 0; i < m_count; ++i)
             {

--- a/src/Box2D.NET.Samples/Samples/Collisions/TimeOfImpact.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/TimeOfImpact.cs
@@ -35,9 +35,9 @@ public class TimeOfImpact : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.6f, 2.0f);
-            m_context.camera.m_center = new B2Vec2(-16, 45);
-            m_context.camera.m_zoom = 5.0f;
+            m_camera.m_center = new B2Vec2(0.6f, 2.0f);
+            m_camera.m_center = new B2Vec2(-16, 45);
+            m_camera.m_zoom = 5.0f;
         }
 
         m_countA = m_verticesA.Length;
@@ -86,7 +86,7 @@ public class TimeOfImpact : Sample
             vertices[i] = b2TransformPoint(ref transformA, m_verticesA[i]);
         }
 
-        m_context.draw.DrawPolygon(vertices, m_countA, B2HexColor.b2_colorGray);
+        m_draw.DrawPolygon(vertices, m_countA, B2HexColor.b2_colorGray);
 
         // Draw B at t = 0
         B2Transform transformB = b2GetSweepTransform(ref _sweepB, 0.0f);
@@ -95,7 +95,7 @@ public class TimeOfImpact : Sample
             vertices[i] = b2TransformPoint(ref transformB, m_verticesB[i]);
         }
 
-        m_context.draw.DrawSolidCapsule(vertices[0], vertices[1], m_radiusB, B2HexColor.b2_colorGreen);
+        m_draw.DrawSolidCapsule(vertices[0], vertices[1], m_radiusB, B2HexColor.b2_colorGreen);
         // m_context.g_draw.DrawPolygon( vertices, m_countB, b2HexColor.b2_colorGreen );
 
         // Draw B at t = hit_time
@@ -105,7 +105,7 @@ public class TimeOfImpact : Sample
             vertices[i] = b2TransformPoint(ref transformB, m_verticesB[i]);
         }
 
-        m_context.draw.DrawPolygon(vertices, m_countB, B2HexColor.b2_colorOrange);
+        m_draw.DrawPolygon(vertices, m_countB, B2HexColor.b2_colorOrange);
 
         // Draw B at t = 1
         transformB = b2GetSweepTransform(ref _sweepB, 1.0f);
@@ -114,7 +114,7 @@ public class TimeOfImpact : Sample
             vertices[i] = b2TransformPoint(ref transformB, m_verticesB[i]);
         }
 
-        m_context.draw.DrawSolidCapsule(vertices[0], vertices[1], m_radiusB, B2HexColor.b2_colorRed);
+        m_draw.DrawSolidCapsule(vertices[0], vertices[1], m_radiusB, B2HexColor.b2_colorRed);
         // m_context.g_draw.DrawPolygon( vertices, m_countB, b2HexColor.b2_colorRed );
 
         if (_output.state == B2TOIState.b2_toiStateHit)

--- a/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
@@ -40,8 +40,8 @@ public class BounceHouse : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 0.45f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 0.45f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -128,7 +128,7 @@ public class BounceHouse : Sample
         base.UpdateGui();
 
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Bounce House", ImGuiWindowFlags.NoResize);
@@ -188,8 +188,8 @@ public class BounceHouse : Sample
             ref HitEvent e = ref m_hitEvents[i];
             if (e.stepIndex > 0 && m_stepCount <= e.stepIndex + 30)
             {
-                m_context.draw.DrawCircle(e.point, 0.1f, B2HexColor.b2_colorOrangeRed);
-                m_context.draw.DrawString(e.point, $"{e.speed:F1}");
+                m_draw.DrawCircle(e.point, 0.1f, B2HexColor.b2_colorOrangeRed);
+                m_draw.DrawString(e.point, $"{e.speed:F1}");
             }
         }
     }

--- a/src/Box2D.NET.Samples/Samples/Continuous/BounceHumans.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/BounceHumans.cs
@@ -34,8 +34,8 @@ public class BounceHumans : Sample
 
     public BounceHumans(SampleContext context) : base(context)
     {
-        m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-        m_context.camera.m_zoom = 12.0f;
+        m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+        m_camera.m_zoom = 12.0f;
 
         for (int i = 0; i < m_humans.Length; ++i)
         {
@@ -107,6 +107,6 @@ public class BounceHumans : Sample
     {
         base.Draw(settings);
 
-        m_context.draw.DrawSegment(b2Vec2_zero, new B2Vec2(3.0f * _cs1.sine, 3.0f * _cs2.cosine), B2HexColor.b2_colorWhite);
+        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(3.0f * _cs1.sine, 3.0f * _cs2.cosine), B2HexColor.b2_colorWhite);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Continuous/ChainDrop.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/ChainDrop.cs
@@ -30,8 +30,8 @@ public class ChainDrop : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 0.35f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 0.35f;
         }
 
         // 
@@ -90,7 +90,7 @@ public class ChainDrop : Sample
         base.UpdateGui();
         
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Chain Drop", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/ChainSlide.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/ChainSlide.cs
@@ -21,8 +21,8 @@ public class ChainSlide : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 10.0f);
-            m_context.camera.m_zoom = 15.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 10.0f);
+            m_camera.m_zoom = 15.0f;
         }
 
         // b2_toiHitCount = 0;

--- a/src/Box2D.NET.Samples/Samples/Continuous/Drop.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/Drop.cs
@@ -36,8 +36,8 @@ public class Drop : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 1.5f);
-            m_context.camera.m_zoom = 3.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 1.5f);
+            m_camera.m_zoom = 3.0f;
             m_context.settings.enableSleep = false;
             m_context.settings.drawJoints = false;
         }

--- a/src/Box2D.NET.Samples/Samples/Continuous/GhostBumps.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/GhostBumps.cs
@@ -46,8 +46,8 @@ public class GhostBumps : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(1.5f, 16.0f);
-            m_context.camera.m_zoom = 25.0f * 0.8f;
+            m_camera.m_center = new B2Vec2(1.5f, 16.0f);
+            m_camera.m_zoom = 25.0f * 0.8f;
         }
 
         m_groundId = b2_nullBodyId;
@@ -272,7 +272,7 @@ public class GhostBumps : Sample
         base.UpdateGui();
         
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Ghost Bumps", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/Pinball.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/Pinball.cs
@@ -32,8 +32,8 @@ public class Pinball : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 9.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 9.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         m_context.settings.drawJoints = false;

--- a/src/Box2D.NET.Samples/Samples/Continuous/PixelImperfect.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/PixelImperfect.cs
@@ -26,8 +26,8 @@ public class PixelImperfect : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(7.0f, 5.0f);
-            m_context.camera.m_zoom = 6.0f;
+            m_camera.m_center = new B2Vec2(7.0f, 5.0f);
+            m_camera.m_zoom = 6.0f;
         }
 
         float pixelsPerMeter = 30.0f;

--- a/src/Box2D.NET.Samples/Samples/Continuous/RestitutionThreshold.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/RestitutionThreshold.cs
@@ -27,8 +27,8 @@ public class RestitutionThreshold : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(7.0f, 5.0f);
-            m_context.camera.m_zoom = 6.0f;
+            m_camera.m_center = new B2Vec2(7.0f, 5.0f);
+            m_camera.m_zoom = 6.0f;
         }
 
         float pixelsPerMeter = 30.0f;

--- a/src/Box2D.NET.Samples/Samples/Continuous/SegmentSlide.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SegmentSlide.cs
@@ -21,8 +21,8 @@ public class SegmentSlide : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 10.0f);
-            m_context.camera.m_zoom = 15.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 10.0f);
+            m_camera.m_zoom = 15.0f;
         }
 
         // b2_toiHitCount = 0;

--- a/src/Box2D.NET.Samples/Samples/Continuous/SkinnyBox.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SkinnyBox.cs
@@ -35,8 +35,8 @@ public class SkinnyBox : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(1.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.25f;
+            m_camera.m_center = new B2Vec2(1.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.25f;
         }
 
         {
@@ -116,7 +116,7 @@ public class SkinnyBox : Sample
         base.UpdateGui();
         
         float height = 110.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Skinny Box", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeFallback.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeFallback.cs
@@ -26,8 +26,8 @@ public class SpeculativeFallback : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(1.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.25f;
+            m_camera.m_center = new B2Vec2(1.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.25f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeGhost.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeGhost.cs
@@ -24,8 +24,8 @@ public class SpeculativeGhost : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 1.75f);
-            m_context.camera.m_zoom = 2.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 1.75f);
+            m_camera.m_zoom = 2.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeSliver.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SpeculativeSliver.cs
@@ -23,8 +23,8 @@ public class SpeculativeSliver : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 1.75f);
-            m_context.camera.m_zoom = 2.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 1.75f);
+            m_camera.m_zoom = 2.5f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Continuous/Wedge.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/Wedge.cs
@@ -23,8 +23,8 @@ public class Wedge : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.5f);
-            m_context.camera.m_zoom = 6.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.5f);
+            m_camera.m_zoom = 6.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Determinisms/FallingHinges.cs
+++ b/src/Box2D.NET.Samples/Samples/Determinisms/FallingHinges.cs
@@ -35,8 +35,8 @@ public class FallingHinges : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 7.5f);
-            m_context.camera.m_zoom = 10.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 7.5f);
+            m_camera.m_zoom = 10.0f;
         }
         m_data = CreateFallingHinges( m_worldId );
         m_done = false;

--- a/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
@@ -42,8 +42,8 @@ public class BodyMove : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.0f, 8.0f);
-            m_context.camera.m_zoom = 25.0f * 0.55f;
+            m_camera.m_center = new B2Vec2(2.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.55f;
         }
 
         {
@@ -139,7 +139,7 @@ public class BodyMove : Sample
         {
             // draw the transform of every body that moved (not sleeping)
             ref B2BodyMoveEvent @event = ref events.moveEvents[i];
-            m_context.draw.DrawTransform(@event.transform);
+            m_draw.DrawTransform(@event.transform);
 
             B2Transform transform = b2Body_GetTransform(@event.bodyId);
             B2_ASSERT(transform.p.X == @event.transform.p.X);
@@ -174,7 +174,7 @@ public class BodyMove : Sample
         base.UpdateGui();
 
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Body Move", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -198,7 +198,7 @@ public class BodyMove : Sample
     {
         base.Draw(settings);
 
-        m_context.draw.DrawCircle(m_explosionPosition, m_explosionRadius, B2HexColor.b2_colorAzure);
+        m_draw.DrawCircle(m_explosionPosition, m_explosionRadius, B2HexColor.b2_colorAzure);
 
         DrawTextLine($"sleep count: {m_sleepCount}");
         

--- a/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
@@ -45,8 +45,8 @@ public class ContactEvent : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 1.75f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 1.75f;
         }
 
         {
@@ -148,7 +148,7 @@ public class ContactEvent : Sample
         base.UpdateGui();
 
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Contact Event", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -232,8 +232,8 @@ public class ContactEvent : Sample
                         for (int k = 0; k < manifold.pointCount; ++k)
                         {
                             B2ManifoldPoint point = manifold.points[k];
-                            m_context.draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorBlueViolet);
-                            m_context.draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
+                            m_draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorBlueViolet);
+                            m_draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
                         }
                     }
                 }
@@ -262,8 +262,8 @@ public class ContactEvent : Sample
                         for (int k = 0; k < manifold.pointCount; ++k)
                         {
                             B2ManifoldPoint point = manifold.points[k];
-                            m_context.draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorYellowGreen);
-                            m_context.draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
+                            m_draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorYellowGreen);
+                            m_draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
                         }
                     }
                 }

--- a/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
@@ -42,8 +42,8 @@ public class FootSensor : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 6.0f);
-            m_context.camera.m_zoom = 7.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 6.0f);
+            m_camera.m_zoom = 7.5f;
         }
 
         {
@@ -147,7 +147,7 @@ public class FootSensor : Sample
             B2ShapeId shapeId = m_overlaps[i];
             B2AABB aabb = b2Shape_GetAABB(shapeId);
             B2Vec2 point = b2AABB_Center(aabb);
-            m_context.draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorWhite);
         }
 
         DrawTextLine($"count == {m_overlapCount}");

--- a/src/Box2D.NET.Samples/Samples/Events/Platformer.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/Platformer.cs
@@ -44,8 +44,8 @@ public class Platformer : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.5f, 7.5f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.5f, 7.5f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         b2World_SetPreSolveCallback(m_worldId, PreSolveStatic, this);
@@ -173,7 +173,7 @@ public class Platformer : Sample
         base.UpdateGui();
         
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("One-Sided Platform", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/SensorBookend.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorBookend.cs
@@ -41,8 +41,8 @@ public class SensorBookend : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 6.0f);
-            m_context.camera.m_zoom = 7.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 6.0f);
+            m_camera.m_zoom = 7.5f;
         }
 
         {
@@ -123,7 +123,7 @@ public class SensorBookend : Sample
     public override void UpdateGui()
     {
         float height = 260.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Sensor Bookend", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
@@ -46,8 +46,8 @@ public class SensorFunnel : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 1.333f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 1.333f;
         }
 
         m_context.settings.drawJoints = false;
@@ -261,7 +261,7 @@ public class SensorFunnel : Sample
         base.UpdateGui();
 
         float height = 90.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Sensor Event", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/SensorTypes.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorTypes.cs
@@ -41,8 +41,8 @@ public class SensorTypes : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 3.0f);
-            m_context.camera.m_zoom = 4.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 3.0f);
+            m_camera.m_zoom = 4.5f;
         }
 
         {
@@ -199,11 +199,11 @@ public class SensorTypes : Sample
         B2Vec2 origin = new B2Vec2(5.0f, 1.0f);
         B2Vec2 translation = new B2Vec2(-10.0f, 0.0f);
         B2RayResult result = b2World_CastRayClosest(m_worldId, origin, translation, b2DefaultQueryFilter());
-        m_context.draw.DrawSegment(origin, origin + translation, B2HexColor.b2_colorDimGray);
+        m_draw.DrawSegment(origin, origin + translation, B2HexColor.b2_colorDimGray);
 
         if (result.hit)
         {
-            m_context.draw.DrawPoint(result.point, 10.0f, B2HexColor.b2_colorCyan);
+            m_draw.DrawPoint(result.point, 10.0f, B2HexColor.b2_colorCyan);
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Geometries/ConvexHull.cs
+++ b/src/Box2D.NET.Samples/Samples/Geometries/ConvexHull.cs
@@ -37,8 +37,8 @@ public class ConvexHull : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.5f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 0.3f;
+            m_camera.m_center = new B2Vec2(0.5f, 0.0f);
+            m_camera.m_zoom = 25.0f * 0.3f;
         }
 
         m_generation = 0;
@@ -214,18 +214,18 @@ public class ConvexHull : Sample
 
         if (0 < m_hull.count)
         {
-            m_context.draw.DrawPolygon(m_hull.points.AsSpan(), m_hull.count, B2HexColor.b2_colorGray);
+            m_draw.DrawPolygon(m_hull.points.AsSpan(), m_hull.count, B2HexColor.b2_colorGray);
         }
 
         for (int i = 0; i < m_count; ++i)
         {
-            m_context.draw.DrawPoint(m_points[i], 5.0f, B2HexColor.b2_colorBlue);
-            m_context.draw.DrawString(b2Add(m_points[i], new B2Vec2(0.1f, 0.1f)), $"{i}");
+            m_draw.DrawPoint(m_points[i], 5.0f, B2HexColor.b2_colorBlue);
+            m_draw.DrawString(b2Add(m_points[i], new B2Vec2(0.1f, 0.1f)), $"{i}");
         }
 
         for (int i = 0; i < m_hull.count; ++i)
         {
-            m_context.draw.DrawPoint(m_hull.points[i], 6.0f, B2HexColor.b2_colorGreen);
+            m_draw.DrawPoint(m_hull.points[i], 6.0f, B2HexColor.b2_colorGreen);
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
@@ -33,8 +33,8 @@ public class BallAndChain : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, -8.0f);
-            m_context.camera.m_zoom = 27.5f;
+            m_camera.m_center = new B2Vec2(0.0f, -8.0f);
+            m_camera.m_zoom = 27.5f;
         }
 
         B2BodyId groundId = b2_nullBodyId;
@@ -105,7 +105,7 @@ public class BallAndChain : Sample
         base.UpdateGui();
 
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Ball and Chain", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
@@ -35,8 +35,8 @@ public class BreakableJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 8.0f);
-            m_context.camera.m_zoom = 25.0f * 0.7f;
+            m_camera.m_center = new B2Vec2(0.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.7f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -210,7 +210,7 @@ public class BreakableJoint : Sample
         base.UpdateGui();
 
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Breakable Joint", ImGuiWindowFlags.NoResize);
@@ -262,7 +262,7 @@ public class BreakableJoint : Sample
             if (b2LengthSquared(force) <= m_breakForce * m_breakForce)
             {
                 B2Vec2 point = b2Joint_GetLocalAnchorA(m_jointIds[i]);
-                m_context.draw.DrawString(point, $"({force.X:F1}, {force.Y:F1})");
+                m_draw.DrawString(point, $"({force.X:F1}, {force.Y:F1})");
             }
         }
     }

--- a/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
@@ -38,7 +38,7 @@ public class Bridge : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 2.5f;
+            m_camera.m_zoom = 25.0f * 2.5f;
         }
 
         B2BodyId groundId = b2_nullBodyId;
@@ -134,7 +134,7 @@ public class Bridge : Sample
         base.UpdateGui();
         
         float height = 80.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Bridge", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
@@ -42,8 +42,8 @@ public class Cantilever : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 0.35f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 0.35f;
         }
 
         B2BodyId groundId = b2_nullBodyId;
@@ -102,7 +102,7 @@ public class Cantilever : Sample
         base.UpdateGui();
 
         float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Cantilever", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
@@ -41,8 +41,8 @@ public class DistanceJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 12.0f);
-            m_context.camera.m_zoom = 25.0f * 0.35f;
+            m_camera.m_center = new B2Vec2(0.0f, 12.0f);
+            m_camera.m_zoom = 25.0f * 0.35f;
         }
 
         {
@@ -129,7 +129,7 @@ public class DistanceJoint : Sample
         base.UpdateGui();
 
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Distance Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/DoohickeyFarm.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/DoohickeyFarm.cs
@@ -23,8 +23,8 @@ public class DoohickeyFarm : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.35f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.35f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
@@ -38,8 +38,8 @@ public class Driving : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center.Y = 5.0f;
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center.Y = 5.0f;
+            m_camera.m_zoom = 25.0f * 0.4f;
             m_context.settings.drawJoints = false;
         }
 
@@ -216,7 +216,7 @@ public class Driving : Sample
         base.UpdateGui();
 
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Driving", ImGuiWindowFlags.NoResize);
@@ -283,6 +283,6 @@ public class Driving : Sample
         
 
         B2Vec2 carPosition = b2Body_GetPosition(m_car.m_chassisId);
-        m_context.camera.m_center.X = carPosition.X;
+        m_camera.m_center.X = carPosition.X;
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/FilterJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/FilterJoint.cs
@@ -25,8 +25,8 @@ public class FilterJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 7.0f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.0f, 7.0f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/FixedRotation.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/FixedRotation.cs
@@ -35,8 +35,8 @@ public class FixedRotation : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 8.0f);
-            m_context.camera.m_zoom = 25.0f * 0.7f;
+            m_camera.m_center = new B2Vec2(0.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.7f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -227,7 +227,7 @@ public class FixedRotation : Sample
         base.UpdateGui();
         
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Fixed Rotation", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
@@ -36,8 +36,8 @@ public class GearLift : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 6.0f);
-            m_context.camera.m_zoom = 7.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 6.0f);
+            m_camera.m_zoom = 7.0f;
         }
 
         B2BodyId groundId;
@@ -293,7 +293,7 @@ public class GearLift : Sample
     public override void UpdateGui()
     {
         float height = 120.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 25.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Gear Lift", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
@@ -43,8 +43,8 @@ public class MotorJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 7.0f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.0f, 7.0f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         B2BodyId groundId;
@@ -92,7 +92,7 @@ public class MotorJoint : Sample
 
 
         float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Motor Joint", ImGuiWindowFlags.NoResize);
@@ -154,6 +154,6 @@ public class MotorJoint : Sample
         float torque = b2Joint_GetConstraintTorque(m_jointId);
 
         DrawTextLine($"force = {force.X:3,F0}, {force.Y:3,F0}, torque = {torque:3,F0}");
-        m_context.draw.DrawTransform(_transform);
+        m_draw.DrawTransform(_transform);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
@@ -23,6 +23,7 @@ public class PrismaticJoint : Sample
     private float m_motorForce;
     private float m_hertz;
     private float m_dampingRatio;
+    private float m_translation;
     private bool m_enableSpring;
     private bool m_enableMotor;
     private bool m_enableLimit;
@@ -36,8 +37,8 @@ public class PrismaticJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 8.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         B2BodyId groundId;
@@ -53,6 +54,7 @@ public class PrismaticJoint : Sample
         m_motorForce = 25.0f;
         m_hertz = 1.0f;
         m_dampingRatio = 0.5f;
+        m_translation = 0.0f;
 
         {
             B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -91,8 +93,8 @@ public class PrismaticJoint : Sample
     {
         base.UpdateGui();
 
-        float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        float height = 240.0f;
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Prismatic Joint", ImGuiWindowFlags.NoResize);
@@ -143,6 +145,12 @@ public class PrismaticJoint : Sample
                 b2PrismaticJoint_SetSpringDampingRatio(m_jointId, m_dampingRatio);
                 b2Joint_WakeBodies(m_jointId);
             }
+
+            if (ImGui.SliderFloat("Translation", ref m_translation, -5.0f, 5.0f, "%.1f"))
+            {
+                b2PrismaticJoint_SetTargetTranslation(m_jointId, m_translation);
+                b2Joint_WakeBodies(m_jointId);
+            }
         }
 
         ImGui.End();
@@ -151,17 +159,16 @@ public class PrismaticJoint : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         float force = b2PrismaticJoint_GetMotorForce(m_jointId);
         DrawTextLine($"Motor Force = {force:4,F1}");
-        
+
 
         float translation = b2PrismaticJoint_GetTranslation(m_jointId);
         DrawTextLine($"Translation = {translation:4,F1}");
-        
+
 
         float speed = b2PrismaticJoint_GetSpeed(m_jointId);
         DrawTextLine($"Speed = {speed:4,F8}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
@@ -30,8 +30,8 @@ public class Ragdoll : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 12.0f);
-            m_context.camera.m_zoom = 16.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 12.0f);
+            m_camera.m_zoom = 16.0f;
 
             // m_context.g_camera.m_center = { 0.0f, 26.0f };
             // m_context.g_camera.m_zoom = 1.0f;
@@ -63,7 +63,7 @@ public class Ragdoll : Sample
         base.UpdateGui();
         
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Ragdoll", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
@@ -26,6 +26,7 @@ public class RevoluteJoint : Sample
     private float m_motorTorque;
     private float m_hertz;
     private float m_dampingRatio;
+    private float m_targetAngle;
     private bool m_enableSpring;
     private bool m_enableMotor;
     private bool m_enableLimit;
@@ -39,8 +40,8 @@ public class RevoluteJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 15.5f);
-            m_context.camera.m_zoom = 25.0f * 0.7f;
+            m_camera.m_center = new B2Vec2(0.0f, 15.5f);
+            m_camera.m_zoom = 25.0f * 0.7f;
         }
 
         B2BodyId groundId = b2_nullBodyId;
@@ -60,6 +61,7 @@ public class RevoluteJoint : Sample
         m_enableMotor = false;
         m_hertz = 1.0f;
         m_dampingRatio = 0.5f;
+        m_targetAngle = 0.0f;
         m_motorSpeed = 1.0f;
         m_motorTorque = 1000.0f;
 
@@ -143,7 +145,7 @@ public class RevoluteJoint : Sample
         base.UpdateGui();
 
         float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Revolute Joint", ImGuiWindowFlags.NoResize);
@@ -183,7 +185,7 @@ public class RevoluteJoint : Sample
 
         if (m_enableSpring)
         {
-            if (ImGui.SliderFloat("Hertz", ref m_hertz, 0.0f, 10.0f, "%.1f"))
+            if (ImGui.SliderFloat("Hertz", ref m_hertz, 0.0f, 30.0f, "%.1f"))
             {
                 b2RevoluteJoint_SetSpringHertz(m_jointId1, m_hertz);
                 b2Joint_WakeBodies(m_jointId1);
@@ -193,6 +195,13 @@ public class RevoluteJoint : Sample
             {
                 b2RevoluteJoint_SetSpringDampingRatio(m_jointId1, m_dampingRatio);
                 b2Joint_WakeBodies(m_jointId1);
+            }
+            
+            
+            if ( ImGui.SliderFloat( "Degrees", ref m_targetAngle, -180.0f, 180.0f, "%.0f" ) )
+            {
+                b2RevoluteJoint_SetTargetAngle( m_jointId1, B2_PI * m_targetAngle / 180.0f );
+                b2Joint_WakeBodies( m_jointId1 );
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
@@ -32,8 +32,8 @@ public class ScissorLift : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 9.0f);
-            m_context.camera.m_zoom = 25.0f * 0.4f;
+            m_camera.m_center = new B2Vec2(0.0f, 9.0f);
+            m_camera.m_zoom = 25.0f * 0.4f;
         }
 
         // Need 8 sub-steps for smoother operation
@@ -204,7 +204,7 @@ public class ScissorLift : Sample
         base.UpdateGui();
 
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Scissor Lift", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/SoftBody.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/SoftBody.cs
@@ -23,8 +23,8 @@ public class SoftBody : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.25f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.25f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/UserConstraint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/UserConstraint.cs
@@ -27,8 +27,8 @@ public class UserConstraint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(3.0f, -1.0f);
-            m_context.camera.m_zoom = 25.0f * 0.15f;
+            m_camera.m_center = new B2Vec2(3.0f, -1.0f);
+            m_camera.m_zoom = 25.0f * 0.15f;
         }
 
         B2Polygon box = b2MakeBox(1.0f, 0.5f);
@@ -53,7 +53,7 @@ public class UserConstraint : Sample
         base.Step();
 
         B2Transform axes = b2Transform_identity;
-        m_context.draw.DrawTransform(axes);
+        m_draw.DrawTransform(axes);
 
         if (m_context.settings.pause)
         {
@@ -102,12 +102,12 @@ public class UserConstraint : Sample
             float C = length - slackLength;
             if (C < 0.0f || length < 0.001f)
             {
-                m_context.draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorLightCyan);
+                m_draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorLightCyan);
                 m_impulses[i] = 0.0f;
                 continue;
             }
 
-            m_context.draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorViolet);
+            m_draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorViolet);
             B2Vec2 axis = b2Normalize(deltaAnchor);
 
             B2Vec2 rB = b2Sub(anchorB, pB);

--- a/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
@@ -35,8 +35,8 @@ public class WheelJoint : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.15f;
+            m_camera.m_center = new B2Vec2(0.0f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.15f;
         }
 
         B2BodyId groundId;
@@ -90,7 +90,7 @@ public class WheelJoint : Sample
         base.UpdateGui();
         
         float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Wheel Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio1.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio1.cs
@@ -25,8 +25,8 @@ public class HighMassRatio1 : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(3.0f, 14.0f);
-            m_context.camera.m_zoom = 25.0f;
+            m_camera.m_center = new B2Vec2(3.0f, 14.0f);
+            m_camera.m_zoom = 25.0f;
         }
 
         float extent = 1.0f;

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio2.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio2.cs
@@ -24,8 +24,8 @@ public class HighMassRatio2 : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 16.5f);
-            m_context.camera.m_zoom = 25.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 16.5f);
+            m_camera.m_zoom = 25.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio3.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio3.cs
@@ -25,8 +25,8 @@ public class HighMassRatio3 : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 16.5f);
-            m_context.camera.m_zoom = 25.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 16.5f);
+            m_camera.m_zoom = 25.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
@@ -35,8 +35,8 @@ public class OverlapRecovery : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 2.5f);
-            m_context.camera.m_zoom = 25.0f * 0.15f;
+            m_camera.m_center = new B2Vec2(0.0f, 2.5f);
+            m_camera.m_zoom = 25.0f * 0.15f;
         }
 
         m_bodyIds = null;
@@ -110,7 +110,7 @@ public class OverlapRecovery : Sample
         base.UpdateGui();
 
         float height = 210.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(220.0f, height));
 
         ImGui.Begin("Overlap Recovery", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Robustness/TinyPyramid.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/TinyPyramid.cs
@@ -25,8 +25,8 @@ public class TinyPyramid : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.8f);
-            m_context.camera.m_zoom = 1.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.8f);
+            m_camera.m_zoom = 1.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Sample.cs
+++ b/src/Box2D.NET.Samples/Samples/Sample.cs
@@ -35,6 +35,9 @@ public class Sample : IDisposable
 #endif
 
     protected SampleContext m_context;
+    protected Camera m_camera;
+    protected Draw m_draw;
+    
     protected TaskScheduler m_scheduler;
     protected SampleTask[] m_tasks;
     protected int m_taskCount;
@@ -54,6 +57,9 @@ public class Sample : IDisposable
     public Sample(SampleContext context)
     {
         m_context = context;
+        m_camera = context.camera;
+        m_draw = context.draw;
+        
         m_scheduler = new TaskScheduler();
         m_scheduler.Initialize(m_context.settings.workerCount);
 
@@ -235,7 +241,7 @@ public class Sample : IDisposable
 
     public void DrawTitle(string title)
     {
-        m_context.draw.DrawString(5, 5, title);
+        m_draw.DrawString(5, 5, title);
         m_textLine = (int)26.0f;
     }
 
@@ -453,7 +459,7 @@ public class Sample : IDisposable
             }
         }
 
-        m_context.draw.m_debugDraw.drawingBounds = m_context.camera.GetViewBounds();
+        m_context.draw.m_debugDraw.drawingBounds = m_camera.GetViewBounds();
         m_context.draw.m_debugDraw.useDrawingBounds = settings.useCameraBounds;
 
         // todo testing

--- a/src/Box2D.NET.Samples/Samples/Shapes/ChainLink.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ChainLink.cs
@@ -23,8 +23,8 @@ public class ChainLink : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         B2Vec2[] points1 = new B2Vec2[]

--- a/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
@@ -41,8 +41,8 @@ public class ChainShape : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 25.0f * 1.75f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 25.0f * 1.75f;
         }
 
         m_groundId = b2_nullBodyId;
@@ -183,13 +183,13 @@ public class ChainShape : Sample
     {
         base.UpdateGui();
 
-        m_context.draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.5f, 0.0f), B2HexColor.b2_colorRed);
-        m_context.draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.0f, 0.5f), B2HexColor.b2_colorGreen);
+        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.5f, 0.0f), B2HexColor.b2_colorRed);
+        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.0f, 0.5f), B2HexColor.b2_colorGreen);
 
         // DrawTextLine($"toi calls, hits = {b2_toiCalls}, {b2_toiHitCount}");
 
         float height = 155.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Chain Shape", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
@@ -35,8 +35,8 @@ public class CompoundShapes : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 6.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 6.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         {
@@ -198,7 +198,7 @@ public class CompoundShapes : Sample
         base.UpdateGui();
 
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Compound Shapes", ImGuiWindowFlags.NoResize);
@@ -220,16 +220,16 @@ public class CompoundShapes : Sample
         if (m_drawBodyAABBs)
         {
             B2AABB aabb = b2Body_ComputeAABB(m_table1Id);
-            m_context.draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_table2Id);
-            m_context.draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_ship1Id);
-            m_context.draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_ship2Id);
-            m_context.draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/ConveyorBelt.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ConveyorBelt.cs
@@ -22,8 +22,8 @@ public class ConveyorBelt : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(2.0f, 7.5f);
-            m_context.camera.m_zoom = 12.0f;
+            m_camera.m_center = new B2Vec2(2.0f, 7.5f);
+            m_camera.m_zoom = 12.0f;
         }
 
         // Ground

--- a/src/Box2D.NET.Samples/Samples/Shapes/CustomFilter.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/CustomFilter.cs
@@ -29,8 +29,8 @@ public class CustomFilter : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 10.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 10.0f;
         }
 
         // Register custom filter
@@ -103,7 +103,7 @@ public class CustomFilter : Sample
         for (int i = 0; i < e_count; ++i)
         {
             B2Vec2 p = b2Body_GetPosition(m_bodyIds[i]);
-            m_context.draw.DrawString(new B2Vec2(p.X, p.Y), $"{i}");
+            m_draw.DrawString(new B2Vec2(p.X, p.Y), $"{i}");
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/EllipseShape.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/EllipseShape.cs
@@ -24,8 +24,8 @@ public class EllipseShape : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.55f;
-            m_context.camera.m_center = new B2Vec2(2.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.55f;
+            m_camera.m_center = new B2Vec2(2.0f, 8.0f);
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
@@ -36,8 +36,8 @@ public class Explosion : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 0.0f);
-            m_context.camera.m_zoom = 14.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 0.0f);
+            m_camera.m_zoom = 14.0f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -84,7 +84,7 @@ public class Explosion : Sample
         base.UpdateGui();
 
         float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Explosion", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -130,7 +130,7 @@ public class Explosion : Sample
         DrawTextLine($"reference angle = {m_referenceAngle:g}");
         
 
-        m_context.draw.DrawCircle(b2Vec2_zero, m_radius + m_falloff, B2HexColor.b2_colorBox2DBlue);
-        m_context.draw.DrawCircle(b2Vec2_zero, m_radius, B2HexColor.b2_colorBox2DYellow);
+        m_draw.DrawCircle(b2Vec2_zero, m_radius + m_falloff, B2HexColor.b2_colorBox2DBlue);
+        m_draw.DrawCircle(b2Vec2_zero, m_radius, B2HexColor.b2_colorBox2DYellow);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/Friction.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Friction.cs
@@ -23,8 +23,8 @@ public class Friction : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 14.0f);
-            m_context.camera.m_zoom = 25.0f * 0.6f;
+            m_camera.m_center = new B2Vec2(0.0f, 14.0f);
+            m_camera.m_zoom = 25.0f * 0.6f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Shapes/ModifyGeometry.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ModifyGeometry.cs
@@ -39,8 +39,8 @@ public class ModifyGeometry : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.25f;
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.25f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
         }
 
         {
@@ -113,7 +113,7 @@ public class ModifyGeometry : Sample
         base.UpdateGui();
         
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Modify Geometry", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/OffsetShapes.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/OffsetShapes.cs
@@ -23,8 +23,8 @@ public class OffsetShapes : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.55f;
-            m_context.camera.m_center = new B2Vec2(2.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.55f;
+            m_camera.m_center = new B2Vec2(2.0f, 8.0f);
         }
 
         {
@@ -62,6 +62,6 @@ public class OffsetShapes : Sample
     {
         base.Draw(settings);
 
-        m_context.draw.DrawTransform(b2Transform_identity);
+        m_draw.DrawTransform(b2Transform_identity);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/RecreateStatic.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/RecreateStatic.cs
@@ -26,8 +26,8 @@ public class RecreateStatic : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 2.5f);
-            m_context.camera.m_zoom = 3.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 2.5f);
+            m_camera.m_zoom = 3.5f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();

--- a/src/Box2D.NET.Samples/Samples/Shapes/Restitution.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Restitution.cs
@@ -37,8 +37,8 @@ public class Restitution : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(4.0f, 17.0f);
-            m_context.camera.m_zoom = 27.5f;
+            m_camera.m_center = new B2Vec2(4.0f, 17.0f);
+            m_camera.m_zoom = 27.5f;
         }
 
         {
@@ -109,7 +109,7 @@ public class Restitution : Sample
         base.UpdateGui();
 
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Restitution", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/RollingResistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/RollingResistance.cs
@@ -26,8 +26,8 @@ public class RollingResistance : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(5.0f, 20.0f);
-            m_context.camera.m_zoom = 27.5f;
+            m_camera.m_center = new B2Vec2(5.0f, 20.0f);
+            m_camera.m_zoom = 27.5f;
         }
 
         m_lift = 0.0f;
@@ -94,7 +94,7 @@ public class RollingResistance : Sample
 
         for (int i = 0; i < 20; ++i)
         {
-            m_context.draw.DrawString(new B2Vec2(-41.5f, 2.0f * i + 1.0f), $"{m_resistScale * i:F2}");
+            m_draw.DrawString(new B2Vec2(-41.5f, 2.0f * i + 1.0f), $"{m_resistScale * i:F2}");
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/RoundedShapes.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/RoundedShapes.cs
@@ -24,8 +24,8 @@ public class RoundedShapes : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.55f;
-            m_context.camera.m_center = new B2Vec2(2.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.55f;
+            m_camera.m_center = new B2Vec2(2.0f, 8.0f);
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Shapes/ShapeFilter.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ShapeFilter.cs
@@ -40,8 +40,8 @@ public class ShapeFilter : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.5f;
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
         }
 
         {
@@ -92,7 +92,7 @@ public class ShapeFilter : Sample
         base.UpdateGui();
         
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Filter", ImGuiWindowFlags.NoResize);
@@ -211,13 +211,13 @@ public class ShapeFilter : Sample
         base.Draw(settings);
         
         B2Vec2 p1 = b2Body_GetPosition(m_player1Id);
-        m_context.draw.DrawString(new B2Vec2(p1.X - 0.5f, p1.Y), "player 1");
+        m_draw.DrawString(new B2Vec2(p1.X - 0.5f, p1.Y), "player 1");
 
         B2Vec2 p2 = b2Body_GetPosition(m_player2Id);
-        m_context.draw.DrawString(new B2Vec2(p2.X - 0.5f, p2.Y), "player 2");
+        m_draw.DrawString(new B2Vec2(p2.X - 0.5f, p2.Y), "player 2");
 
         B2Vec2 p3 = b2Body_GetPosition(m_player3Id);
-        m_context.draw.DrawString(new B2Vec2(p3.X - 0.5f, p3.Y), "player 3");
+        m_draw.DrawString(new B2Vec2(p3.X - 0.5f, p3.Y), "player 3");
 
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/TangentSpeed.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/TangentSpeed.cs
@@ -30,8 +30,8 @@ public class TangentSpeed : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(60.0f, -15.0f);
-            m_context.camera.m_zoom = 38.0f;
+            m_camera.m_center = new B2Vec2(60.0f, -15.0f);
+            m_camera.m_zoom = 38.0f;
         }
 
         {
@@ -117,7 +117,7 @@ public class TangentSpeed : Sample
     public override void UpdateGui()
     {
         float height = 80.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(260.0f, height));
 
         ImGui.Begin("Ball Parameters", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Stackings/Arch.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/Arch.cs
@@ -24,8 +24,8 @@ public class Arch : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 8.0f);
-            m_context.camera.m_zoom = 25.0f * 0.35f;
+            m_camera.m_center = new B2Vec2(0.0f, 8.0f);
+            m_camera.m_zoom = 25.0f * 0.35f;
         }
 
         B2Vec2[] ps1 = new B2Vec2[]

--- a/src/Box2D.NET.Samples/Samples/Stackings/CapsuleStack.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/CapsuleStack.cs
@@ -27,8 +27,8 @@ public class CapsuleStack : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 6.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 6.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Stackings/CardHouse.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/CardHouse.cs
@@ -24,8 +24,8 @@ public class CardHouse : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.75f, 0.9f);
-            m_context.camera.m_zoom = 25.0f * 0.05f;
+            m_camera.m_center = new B2Vec2(0.75f, 0.9f);
+            m_camera.m_zoom = 25.0f * 0.05f;
         }
 
         B2BodyDef bodyDef = b2DefaultBodyDef();

--- a/src/Box2D.NET.Samples/Samples/Stackings/CircleStack.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/CircleStack.cs
@@ -36,8 +36,8 @@ public class CircleStack : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 6.0f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 6.0f;
         }
 
         int shapeIndex = 0;
@@ -101,7 +101,7 @@ public class CircleStack : Sample
             int indexA = (int)userDataA;
             int indexB = (int)userDataB;
 
-            m_context.draw.DrawPoint(@event.point, 10.0f, B2HexColor.b2_colorWhite);
+            m_draw.DrawPoint(@event.point, 10.0f, B2HexColor.b2_colorWhite);
 
             m_events.Add(new Event(indexA, indexB));
         }

--- a/src/Box2D.NET.Samples/Samples/Stackings/Cliff.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/Cliff.cs
@@ -30,8 +30,8 @@ public class Cliff : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_zoom = 25.0f * 0.5f;
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
         }
 
         {
@@ -147,7 +147,7 @@ public class Cliff : Sample
         base.UpdateGui();
         
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(160.0f, height));
 
         ImGui.Begin("Cliff", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Stackings/Confined.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/Confined.cs
@@ -30,8 +30,8 @@ public class Confined : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 10.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 10.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Stackings/DoubleDomino.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/DoubleDomino.cs
@@ -22,8 +22,8 @@ public class DoubleDomino : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 4.0f);
-            m_context.camera.m_zoom = 25.0f * 0.25f;
+            m_camera.m_center = new B2Vec2(0.0f, 4.0f);
+            m_camera.m_zoom = 25.0f * 0.25f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Stackings/SingleBox.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/SingleBox.cs
@@ -24,8 +24,8 @@ public class SingleBox : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 2.5f);
-            m_context.camera.m_zoom = 3.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 2.5f);
+            m_camera.m_zoom = 3.5f;
         }
 
         float extent = 1.0f;

--- a/src/Box2D.NET.Samples/Samples/Stackings/TiltedStack.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/TiltedStack.cs
@@ -29,8 +29,8 @@ public class TiltedStack : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(7.5f, 7.5f);
-            m_context.camera.m_zoom = 20.0f;
+            m_camera.m_center = new B2Vec2(7.5f, 7.5f);
+            m_camera.m_zoom = 20.0f;
         }
 
         {

--- a/src/Box2D.NET.Samples/Samples/Stackings/VerticalStack.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/VerticalStack.cs
@@ -52,8 +52,8 @@ public class VerticalStack : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(-7.0f, 9.0f);
-            m_context.camera.m_zoom = 14.0f;
+            m_camera.m_center = new B2Vec2(-7.0f, 9.0f);
+            m_camera.m_zoom = 14.0f;
         }
 
         {
@@ -225,7 +225,7 @@ public class VerticalStack : Sample
         base.UpdateGui();
         
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Vertical Stack", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
@@ -55,8 +55,8 @@ public class LargeWorld : Sample
 
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = m_viewPosition;
-            m_context.camera.m_zoom = 25.0f * 1.0f;
+            m_camera.m_center = m_viewPosition;
+            m_camera.m_zoom = 25.0f * 1.0f;
             m_context.settings.drawJoints = false;
             m_context.settings.useCameraBounds = true;
         }
@@ -172,7 +172,7 @@ public class LargeWorld : Sample
         base.UpdateGui();
 
         float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Large World", ImGuiWindowFlags.NoResize);
@@ -205,12 +205,12 @@ public class LargeWorld : Sample
 
         if (m_speed != 0.0f)
         {
-            m_context.camera.m_center = m_viewPosition;
+            m_camera.m_center = m_viewPosition;
         }
 
         if (m_followCar)
         {
-            m_context.camera.m_center.X = b2Body_GetPosition(m_car.m_chassisId).X;
+            m_camera.m_center.X = b2Body_GetPosition(m_car.m_chassisId).X;
         }
 
         float radius = 2.0f;
@@ -230,7 +230,7 @@ public class LargeWorld : Sample
 
         if (m_explode)
         {
-            m_context.draw.DrawCircle(m_explosionPosition, radius, B2HexColor.b2_colorAzure);
+            m_draw.DrawCircle(m_explosionPosition, radius, B2HexColor.b2_colorAzure);
         }
 
         if (GetKey(Keys.A) == InputAction.Press)

--- a/src/Box2D.NET.Samples/Samples/Worlds/WorkbenchWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Worlds/WorkbenchWorld.cs
@@ -17,8 +17,8 @@ public class WorkbenchWorld : Sample
     {
         if (m_context.settings.restart == false)
         {
-            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
-            m_context.camera.m_zoom = 25.0f * 0.5f;
+            m_camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_camera.m_zoom = 25.0f * 0.5f;
         }
 
         B2ShapeId shapeIdA = CreateCircle(m_worldId, new B2Vec2(0.0f, 0.0f), 1.0f);

--- a/src/Box2D.NET/B2Contacts.cs
+++ b/src/Box2D.NET/B2Contacts.cs
@@ -479,7 +479,7 @@ namespace Box2D.NET
             int pointCount = contactSim.manifold.pointCount;
             bool touching = pointCount > 0;
 
-            if (touching && null != world.preSolveFcn && (contactSim.simFlags & (uint)B2ContactSimFlags.b2_simEnablePreSolveEvents) != 0)
+            if (touching && world.preSolveFcn != null && (contactSim.simFlags & (uint)B2ContactSimFlags.b2_simEnablePreSolveEvents) != 0)
             {
                 B2ShapeId shapeIdA = new B2ShapeId(shapeA.id + 1, world.worldId, shapeA.generation);
                 B2ShapeId shapeIdB = new B2ShapeId(shapeB.id + 1, world.worldId, shapeB.generation);

--- a/src/Box2D.NET/B2Joints.cs
+++ b/src/Box2D.NET/B2Joints.cs
@@ -549,12 +549,6 @@ namespace Box2D.NET
             joint.uj.revoluteJoint = empty;
 
             joint.uj.revoluteJoint.referenceAngle = b2ClampFloat(def.referenceAngle, -B2_PI, B2_PI);
-            joint.uj.revoluteJoint.linearImpulse = b2Vec2_zero;
-            joint.uj.revoluteJoint.axialMass = 0.0f;
-            joint.uj.revoluteJoint.springImpulse = 0.0f;
-            joint.uj.revoluteJoint.motorImpulse = 0.0f;
-            joint.uj.revoluteJoint.lowerImpulse = 0.0f;
-            joint.uj.revoluteJoint.upperImpulse = 0.0f;
             joint.uj.revoluteJoint.hertz = def.hertz;
             joint.uj.revoluteJoint.dampingRatio = def.dampingRatio;
             joint.uj.revoluteJoint.lowerAngle = def.lowerAngle;

--- a/src/Box2D.NET/B2PrismaticJoint.cs
+++ b/src/Box2D.NET/B2PrismaticJoint.cs
@@ -14,6 +14,7 @@ namespace Box2D.NET
         public float upperImpulse;
         public float hertz;
         public float dampingRatio;
+        public float targetTranslation;
         public float maxMotorForce;
         public float motorSpeed;
         public float referenceAngle;

--- a/src/Box2D.NET/B2PrismaticJoints.cs
+++ b/src/Box2D.NET/B2PrismaticJoints.cs
@@ -55,6 +55,20 @@ namespace Box2D.NET
             return joint.uj.prismaticJoint.dampingRatio;
         }
 
+        /// Set the prismatic joint spring target angle, usually in meters
+        public static void b2PrismaticJoint_SetTargetTranslation(B2JointId jointId, float translation)
+        {
+            B2JointSim joint = b2GetJointSimCheckType(jointId, B2JointType.b2_prismaticJoint);
+            joint.uj.prismaticJoint.targetTranslation = translation;
+        }
+
+        /// Get the prismatic joint spring target translation, usually in meters
+        public static float b2PrismaticJoint_GetTargetTranslation(B2JointId jointId)
+        {
+            B2JointSim joint = b2GetJointSimCheckType(jointId, B2JointType.b2_prismaticJoint);
+            return joint.uj.prismaticJoint.targetTranslation;
+        }
+
         public static void b2PrismaticJoint_EnableLimit(B2JointId jointId, bool enableLimit)
         {
             B2JointSim joint = b2GetJointSimCheckType(jointId, B2JointType.b2_prismaticJoint);
@@ -420,7 +434,7 @@ namespace Box2D.NET
             if (joint.enableSpring)
             {
                 // This is a real spring and should be applied even during relax
-                float C = translation;
+                float C = translation - joint.targetTranslation;
                 float bias = joint.springSoftness.biasRate * C;
                 float massScale = joint.springSoftness.massScale;
                 float impulseScale = joint.springSoftness.impulseScale;

--- a/src/Box2D.NET/B2RevoluteJoint.cs
+++ b/src/Box2D.NET/B2RevoluteJoint.cs
@@ -13,6 +13,7 @@ namespace Box2D.NET
         public float upperImpulse;
         public float hertz;
         public float dampingRatio;
+        public float targetAngle;
         public float maxMotorTorque;
         public float motorSpeed;
         public float referenceAngle;

--- a/src/Box2D.NET/B2Solvers.cs
+++ b/src/Box2D.NET/B2Solvers.cs
@@ -59,7 +59,7 @@ namespace Box2D.NET
         {
             if (hertz == 0.0f)
             {
-                return new B2Softness(0.0f, 1.0f, 0.0f);
+                return new B2Softness(0.0f, 0.0f, 0.0f);
             }
 
             float omega = 2.0f * B2_PI * hertz;
@@ -372,7 +372,7 @@ namespace Box2D.NET
                 }
             }
 
-            if (didHit && (shape.enablePreSolveEvents || fastShape.enablePreSolveEvents))
+            if (didHit && (shape.enablePreSolveEvents || fastShape.enablePreSolveEvents) && world.preSolveFcn != null)
             {
                 // Pre-solve is expensive because I need to compute a temporary manifold
                 B2Transform transformA = b2GetSweepTransform(ref input.sweepA, hitFraction);


### PR DESCRIPTION
presolve null check
restored character sample
fixed softness for 0 hertz