### PR TITLE
[upstream] Tunable joint stiffness (box2d #934)

### DIFF
--- a/src/Box2D.NET.Samples/SampleApp.cs
+++ b/src/Box2D.NET.Samples/SampleApp.cs
@@ -417,7 +417,7 @@ public class SampleApp
         long sizeAligned = ((size - 1) | (uint)(alignment - 1)) + 1;
         B2_ASSERT((sizeAligned & (alignment - 1)) == 0);
 
-// #if defined( _WIN64 ) || defined( _WIN32 )
+// #if defined( _MSC_VER ) || defined( __MINGW32__ ) || defined( __MINGW64__ )
 //         void* ptr = _aligned_malloc( sizeAligned, alignment );
 // #else
 //         void* ptr = aligned_alloc(alignment, sizeAligned);
@@ -429,7 +429,7 @@ public class SampleApp
 
     private void FreeFcn(byte[] mem)
     {
-// #if defined( _WIN64 ) || defined( _WIN32 )
+// #if defined( _MSC_VER ) || defined( __MINGW32__ ) || defined( __MINGW64__ )
 //         _aligned_free( mem );
 // #else
 //         free(mem);
@@ -737,8 +737,8 @@ public class SampleApp
                 if (ImGui.BeginTabItem("Controls"))
                 {
                     ImGui.PushItemWidth(100.0f);
-                    ImGui.SliderInt("Sub-steps", ref _context.settings.subStepCount, 1, 50);
-                    ImGui.SliderFloat("Hertz", ref _context.settings.hertz, 5.0f, 120.0f, "%.0f hz");
+                    ImGui.SliderInt("Sub-steps", ref _context.settings.subStepCount, 1, 32);
+                    ImGui.SliderFloat("Hertz", ref _context.settings.hertz, 5.0f, 240.0f, "%.0f hz");
 
                     if (ImGui.SliderInt("Workers", ref _context.settings.workerCount, 1, maxWorkers))
                     {

--- a/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
+++ b/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
@@ -397,13 +397,8 @@ public class Mover : Sample
         {
             float pogoCurrentLength = castResult.fraction * rayLength;
 
-            float zeta = m_pogoDampingRatio;
-            float hertz = m_pogoHertz;
-            float omega = 2.0f * B2_PI * hertz;
-            float omegaH = omega * timeStep;
-
-            m_pogoVelocity = (m_pogoVelocity - omega * omegaH * (pogoCurrentLength - pogoRestLength)) /
-                             (1.0f + 2.0f * zeta * omegaH + omegaH * omegaH);
+            float offset = pogoCurrentLength - pogoRestLength;
+            m_pogoVelocity = b2SpringDamper(m_pogoHertz, m_pogoDampingRatio, offset, m_pogoVelocity, timeStep);
 
             B2Vec2 delta = castResult.fraction * translation;
             m_draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
@@ -445,15 +440,13 @@ public class Mover : Sample
             mover.radius = m_capsule.radius;
 
             b2World_CollideMover(m_worldId, ref mover, collideFilter, PlaneResultFcn, this);
-            B2PlaneSolverResult solverResult = b2SolvePlanes(target, m_planes, m_planeCount);
+            B2PlaneSolverResult result = b2SolvePlanes(target - m_transform.p, m_planes, m_planeCount);
 
-            m_totalIterations += solverResult.iterationCount;
+            m_totalIterations += result.iterationCount;
 
-            B2Vec2 moverTranslation = solverResult.position - m_transform.p;
+            float fraction = b2World_CastMover(m_worldId, ref mover, result.translation, castFilter);
 
-            float fraction = b2World_CastMover(m_worldId, ref mover, moverTranslation, castFilter);
-
-            B2Vec2 delta = fraction * moverTranslation;
+            B2Vec2 delta = fraction * result.translation;
             m_transform.p += delta;
 
             if (b2LengthSquared(delta) < tolerance * tolerance)

--- a/src/Box2D.NET.Samples/Samples/Determinisms/FallingHinges.cs
+++ b/src/Box2D.NET.Samples/Samples/Determinisms/FallingHinges.cs
@@ -38,7 +38,8 @@ public class FallingHinges : Sample
             m_camera.m_center = new B2Vec2(0.0f, 7.5f);
             m_camera.m_zoom = 10.0f;
         }
-        m_data = CreateFallingHinges( m_worldId );
+
+        m_data = CreateFallingHinges(m_worldId);
         m_done = false;
     }
 
@@ -47,9 +48,9 @@ public class FallingHinges : Sample
     {
         base.Step();
 
-        if (m_done == false)
+        if (m_context.settings.pause == false && m_done == false)
         {
-            m_done = UpdateFallingHinges( m_worldId, ref m_data );
+            m_done = UpdateFallingHinges(m_worldId, ref m_data);
         }
     }
 
@@ -60,7 +61,6 @@ public class FallingHinges : Sample
         if (m_done)
         {
             DrawTextLine($"sleep step = {m_data.sleepStep}, hash = 0x{m_data.hash:X8}");
-            
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Doohickey.cs
+++ b/src/Box2D.NET.Samples/Samples/Doohickey.cs
@@ -13,17 +13,16 @@ namespace Box2D.NET.Samples.Samples;
 
 public class Doohickey
 {
-    B2BodyId m_wheelId1;
-    B2BodyId m_wheelId2;
-    B2BodyId m_barId1;
-    B2BodyId m_barId2;
+    private B2BodyId m_wheelId1;
+    private B2BodyId m_wheelId2;
+    private B2BodyId m_barId1;
+    private B2BodyId m_barId2;
 
-    B2JointId m_axleId1;
-    B2JointId m_axleId2;
-    B2JointId m_sliderId;
+    private B2JointId m_axleId1;
+    private B2JointId m_axleId2;
+    private B2JointId m_sliderId;
 
-    bool m_isSpawned;
-
+    private bool m_isSpawned;
 
     public Doohickey()
     {
@@ -37,6 +36,8 @@ public class Doohickey
         bodyDef.type = B2BodyType.b2_dynamicBody;
 
         B2ShapeDef shapeDef = b2DefaultShapeDef();
+        shapeDef.material.rollingResistance = 0.1f;
+        
         B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 1.0f * scale);
         B2Capsule capsule = new B2Capsule(new B2Vec2(-3.5f * scale, 0.0f), new B2Vec2(3.5f * scale, 0.0f), 0.15f * scale);
 

--- a/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
@@ -51,7 +51,8 @@ public class BallAndChain : Sample
 
             B2ShapeDef shapeDef = b2DefaultShapeDef();
             shapeDef.density = 20.0f;
-
+            shapeDef.filter.categoryBits = 0x1;
+            shapeDef.filter.maskBits = 0x2;
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
 
             int jointIndex = 0;
@@ -70,8 +71,10 @@ public class BallAndChain : Sample
                 jointDef.bodyIdB = bodyId;
                 jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
                 jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-                // jointDef.enableMotor = true;
+                jointDef.enableMotor = true;
                 jointDef.maxMotorTorque = m_frictionTorque;
+                jointDef.enableSpring = i > 0;
+                jointDef.hertz = 4.0f;
                 m_jointIds[jointIndex++] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 prevBodyId = bodyId;
@@ -83,8 +86,10 @@ public class BallAndChain : Sample
                 B2BodyDef bodyDef = b2DefaultBodyDef();
                 bodyDef.type = B2BodyType.b2_dynamicBody;
                 bodyDef.position = new B2Vec2((1.0f + 2.0f * m_count) * hx + circle.radius - hx, m_count * hx);
-
                 B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
+                
+                shapeDef.filter.categoryBits = 0x2;
+                shapeDef.filter.maskBits = 0x1;
                 b2CreateCircleShape(bodyId, ref shapeDef, ref circle);
 
                 B2Vec2 pivot = new B2Vec2((2.0f * m_count) * hx, m_count * hx);
@@ -94,6 +99,8 @@ public class BallAndChain : Sample
                 jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
                 jointDef.enableMotor = true;
                 jointDef.maxMotorTorque = m_frictionTorque;
+                jointDef.enableSpring = true;
+                jointDef.hertz = 4.0f;
                 m_jointIds[jointIndex++] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
                 B2_ASSERT(jointIndex == m_count + 1);
             }

--- a/src/Box2D.NET.Samples/Samples/Joints/Door.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Door.cs
@@ -24,6 +24,8 @@ public class Door : Sample
     private B2JointId m_jointId;
     private float m_impulse;
     private float m_translationError;
+    private float m_jointHertz;
+    private float m_jointDampingRatio;
     private bool m_enableLimit;
 
     private static Sample Create(SampleContext context)
@@ -47,6 +49,10 @@ public class Door : Sample
         }
 
         m_enableLimit = true;
+        m_impulse = 50000.0f;
+        m_translationError = 0.0f;
+        m_jointHertz = 240.0f;
+        m_jointDampingRatio = 1.0f;
 
         {
             B2BodyDef bodyDef = b2DefaultBodyDef();
@@ -62,12 +68,11 @@ public class Door : Sample
             B2Polygon box = b2MakeBox(0.1f, 1.5f);
             b2CreatePolygonShape(m_doorId, ref shapeDef, ref box);
 
-            B2Vec2 pivot = new B2Vec2(0.0f, 0.0f);
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
             jointDef.bodyIdA = groundId;
             jointDef.bodyIdB = m_doorId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
+            jointDef.localAnchorB = new B2Vec2(0.0f, -1.5f);
             jointDef.targetAngle = 0.0f;
             jointDef.enableSpring = true;
             jointDef.hertz = 1.0f;
@@ -81,10 +86,8 @@ public class Door : Sample
             jointDef.enableLimit = m_enableLimit;
 
             m_jointId = b2CreateRevoluteJoint(m_worldId, ref jointDef);
+            b2Joint_SetConstraintTuning(m_jointId, m_jointHertz, m_jointDampingRatio);
         }
-
-        m_impulse = 50000.0f;
-        m_translationError = 0.0f;
     }
 
     public override void UpdateGui()
@@ -109,6 +112,16 @@ public class Door : Sample
             b2RevoluteJoint_EnableLimit(m_jointId, m_enableLimit);
         }
 
+        if ( ImGui.SliderFloat( "hertz", ref m_jointHertz, 15.0f, 480.0f, "%.0f" ) )
+        {
+            b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
+        }
+
+        if ( ImGui.SliderFloat( "damping", ref m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
+        {
+            b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
+        }
+        
         ImGui.End();
     }
 

--- a/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
@@ -79,7 +79,7 @@ public class GearLift : Sample
         float linkCount = 40;
         float doorHalfHeight = 1.5f;
 
-        B2Vec2 gearPosition1 = new B2Vec2(-4.25f, 10.25f);
+        B2Vec2 gearPosition1 = new B2Vec2(-4.25f, 9.75f);
         B2Vec2 gearPosition2 = gearPosition1 + new B2Vec2(2.0f, 1.0f);
         B2Vec2 linkAttachPosition = gearPosition2 + new B2Vec2(gearRadius + 2.0f * toothHalfWidth + toothRadius, 0.0f);
         B2Vec2 doorPosition = linkAttachPosition - new B2Vec2(0.0f, 2.0f * linkCount * linkHalfLength + doorHalfHeight);

--- a/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
@@ -26,6 +26,8 @@ public class JointSeparation : Sample
     private B2BodyId[] m_bodyIds = new B2BodyId[e_count];
     private B2JointId[] m_jointIds = new B2JointId[e_count];
     private float m_impulse;
+    private float m_jointHertz;
+    private float m_jointDampingRatio;
 
     private static Sample Create(SampleContext context)
     {
@@ -171,11 +173,13 @@ public class JointSeparation : Sample
         }
 
         m_impulse = 500.0f;
+        m_jointHertz = 60.0f;
+        m_jointDampingRatio = 2.0f;
     }
 
     public override void UpdateGui()
     {
-        float height = 120.0f;
+        float height = 180.0f;
         ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(260.0f, height));
 
@@ -197,6 +201,22 @@ public class JointSeparation : Sample
         }
 
         ImGui.SliderFloat("magnitude", ref m_impulse, 0.0f, 1000.0f, "%.0f");
+
+        if (ImGui.SliderFloat("hertz", ref m_jointHertz, 15.0f, 120.0f, "%.0f"))
+        {
+            for (int i = 0; i < e_count; ++i)
+            {
+                b2Joint_SetConstraintTuning(m_jointIds[i], m_jointHertz, m_jointDampingRatio);
+            }
+        }
+
+        if (ImGui.SliderFloat("damping", ref m_jointDampingRatio, 0.0f, 10.0f, "%.1f"))
+        {
+            for (int i = 0; i < e_count; ++i)
+            {
+                b2Joint_SetConstraintTuning(m_jointIds[i], m_jointHertz, m_jointDampingRatio);
+            }
+        }
 
         ImGui.End();
     }

--- a/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
@@ -8,6 +8,7 @@ using ImGuiNET;
 using static Box2D.NET.B2Types;
 using static Box2D.NET.B2Bodies;
 using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Worlds;
 using static Box2D.NET.Shared.Humans;
 
 namespace Box2D.NET.Samples.Samples.Joints;
@@ -15,7 +16,7 @@ namespace Box2D.NET.Samples.Samples.Joints;
 public class Ragdoll : Sample
 {
     private static readonly int SampleRagdoll = SampleFactory.Shared.RegisterSample("Joints", "Ragdoll", Create);
-    
+
     private Human m_human;
     private float m_jointFrictionTorque;
     private float m_jointHertz;
@@ -50,18 +51,20 @@ public class Ragdoll : Sample
         m_jointDampingRatio = 0.5f;
 
         Spawn();
+
+        b2World_SetContactTuning(m_worldId, 240.0f, 0.0f, 2.0f);
     }
 
     void Spawn()
     {
         CreateHuman(ref m_human, m_worldId, new B2Vec2(0.0f, 25.0f), 1.0f, m_jointFrictionTorque, m_jointHertz, m_jointDampingRatio, 1, null, false);
-        Human_ApplyRandomAngularImpulse(ref m_human, 10.0f);
+        //Human_ApplyRandomAngularImpulse(ref m_human, 10.0f);
     }
 
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
         float height = 140.0f;
         ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));

--- a/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
@@ -92,8 +92,6 @@ public class ScissorLift : Sample
                 revoluteDef.bodyIdB = bodyId1;
                 revoluteDef.localAnchorA = baseAnchor1;
                 revoluteDef.localAnchorB = new B2Vec2(-2.5f, 0.0f);
-                revoluteDef.enableMotor = false;
-                revoluteDef.maxMotorTorque = 1.0f;
                 revoluteDef.collideConnected = (i == 0) ? true : false;
 
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
@@ -118,8 +116,6 @@ public class ScissorLift : Sample
                     revoluteDef.bodyIdB = bodyId2;
                     revoluteDef.localAnchorA = baseAnchor2;
                     revoluteDef.localAnchorB = new B2Vec2(2.5f, 0.0f);
-                    revoluteDef.enableMotor = false;
-                    revoluteDef.maxMotorTorque = 1.0f;
                     revoluteDef.collideConnected = false;
 
                     b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
@@ -130,8 +126,6 @@ public class ScissorLift : Sample
                 revoluteDef.bodyIdB = bodyId2;
                 revoluteDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
                 revoluteDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
-                revoluteDef.enableMotor = false;
-                revoluteDef.maxMotorTorque = 1.0f;
                 revoluteDef.collideConnected = false;
 
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
@@ -157,8 +151,6 @@ public class ScissorLift : Sample
                 revoluteDef.bodyIdB = baseId1;
                 revoluteDef.localAnchorA = new B2Vec2(-2.5f, -0.4f);
                 revoluteDef.localAnchorB = baseAnchor1;
-                revoluteDef.enableMotor = false;
-                revoluteDef.maxMotorTorque = 1.0f;
                 revoluteDef.collideConnected = true;
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
             }

--- a/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
@@ -1,0 +1,181 @@
+﻿// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System.Numerics;
+using ImGuiNET;
+using static Box2D.NET.B2Geometries;
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Worlds;
+using static Box2D.NET.B2Joints;
+using static Box2D.NET.B2Ids;
+using static Box2D.NET.B2MathFunction;
+
+namespace Box2D.NET.Samples.Samples.Robustness;
+
+// High gravity and high mass ratio
+public class Cart : Sample
+{
+    private static readonly int SampleCart = SampleFactory.Shared.RegisterSample("Robustness", "Cart", Create);
+
+    private B2BodyId m_chassisId;
+    private B2BodyId m_wheelId1;
+    private B2BodyId m_wheelId2;
+    private B2JointId m_jointId1;
+    private B2JointId m_jointId2;
+
+    private float m_contactHertz;
+    private float m_contactDampingRatio;
+    private float m_contactSpeed;
+    private float m_jointHertz;
+    private float m_jointDampingRatio;
+
+    private static Sample Create(SampleContext context)
+    {
+        return new Cart(context);
+    }
+
+    public Cart(SampleContext context) : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.0f, 1.0f);
+            m_context.camera.m_zoom = 1.5f;
+        }
+
+        B2BodyId groundId;
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.position = new B2Vec2(0.0f, -1.0f);
+            groundId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            B2Polygon groundBox = b2MakeBox(20.0f, 1.0f);
+            b2CreatePolygonShape(groundId, ref shapeDef, ref groundBox);
+        }
+
+        b2World_SetGravity(m_worldId, new B2Vec2(0, -22));
+
+        m_contactHertz = 30.0f;
+        m_contactDampingRatio = 10.0f;
+        m_contactSpeed = 3.0f;
+        b2World_SetContactTuning(m_worldId, m_contactHertz, m_contactDampingRatio, m_contactSpeed);
+
+        m_jointHertz = 60.0f;
+        m_jointDampingRatio = 1.0f;
+
+        m_chassisId = new B2BodyId();
+        m_wheelId1 = new B2BodyId();
+        m_wheelId2 = new B2BodyId();
+
+        CreateScene();
+    }
+
+    void CreateScene()
+    {
+        if (B2_IS_NON_NULL(m_chassisId))
+        {
+            b2DestroyBody(m_chassisId);
+        }
+
+        if (B2_IS_NON_NULL(m_wheelId1))
+        {
+            b2DestroyBody(m_wheelId1);
+        }
+
+        if (B2_IS_NON_NULL(m_wheelId2))
+        {
+            b2DestroyBody(m_wheelId2);
+        }
+
+        float yBase = 2.0f;
+
+        B2BodyDef bodyDef = b2DefaultBodyDef();
+        bodyDef.type = B2BodyType.b2_dynamicBody;
+        bodyDef.position = new B2Vec2(0.0f, yBase);
+        m_chassisId = b2CreateBody(m_worldId, ref bodyDef);
+
+        B2ShapeDef shapeDef = b2DefaultShapeDef();
+        shapeDef.density = 100.0f;
+
+        B2Polygon box = b2MakeOffsetBox(0.5f, 0.25f, new B2Vec2(0.0f, 0.25f), b2Rot_identity);
+        b2CreatePolygonShape(m_chassisId, ref shapeDef, ref box);
+
+        shapeDef = b2DefaultShapeDef();
+        shapeDef.material.rollingResistance = 0.02f;
+        shapeDef.density = 10.0f;
+
+        B2Circle circle = new B2Circle(b2Vec2_zero, 0.1f);
+        bodyDef.position = new B2Vec2(-0.4f, yBase - 0.15f);
+        m_wheelId1 = b2CreateBody(m_worldId, ref bodyDef);
+        b2CreateCircleShape(m_wheelId1, ref shapeDef, ref circle);
+
+        bodyDef.position = new B2Vec2(0.4f, yBase - 0.15f);
+        m_wheelId2 = b2CreateBody(m_worldId, ref bodyDef);
+        b2CreateCircleShape(m_wheelId2, ref shapeDef, ref circle);
+
+        B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
+        jointDef.bodyIdA = m_chassisId;
+        jointDef.bodyIdB = m_wheelId1;
+        jointDef.localAnchorA = new B2Vec2(-0.4f, -0.15f);
+        jointDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
+
+        m_jointId1 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
+        b2Joint_SetConstraintTuning(m_jointId1, m_jointHertz, m_jointDampingRatio);
+
+        jointDef.bodyIdA = m_chassisId;
+        jointDef.bodyIdB = m_wheelId2;
+        jointDef.localAnchorA = new B2Vec2(0.4f, -0.15f);
+        jointDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
+
+        m_jointId2 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
+        b2Joint_SetConstraintTuning(m_jointId2, m_jointHertz, m_jointDampingRatio);
+    }
+
+    public override void UpdateGui()
+    {
+        base.UpdateGui();
+
+        float height = 240.0f;
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(320.0f, height));
+
+        ImGui.Begin("Cart", ImGuiWindowFlags.NoResize);
+        ImGui.PushItemWidth(200.0f);
+
+        bool changed = false;
+        ImGui.Text("Contact");
+        changed = changed || ImGui.SliderFloat("Hertz##contact", ref m_contactHertz, 0.0f, 240.0f, "%.f");
+        changed = changed || ImGui.SliderFloat("Damping Ratio##contact", ref m_contactDampingRatio, 0.0f, 1000.0f, "%.f");
+        changed = changed || ImGui.SliderFloat("Speed", ref m_contactSpeed, 0.0f, 5.0f, "%.1f");
+
+        if (changed)
+        {
+            b2World_SetContactTuning(m_worldId, m_contactHertz, m_contactDampingRatio, m_contactSpeed);
+            CreateScene();
+        }
+
+        ImGui.Separator();
+
+        changed = false;
+        ImGui.Text("Joint");
+        changed = changed || ImGui.SliderFloat("Hertz##joint", ref m_jointHertz, 0.0f, 240.0f, "%.f");
+        changed = changed || ImGui.SliderFloat("Damping Ratio##joint", ref m_jointDampingRatio, 0.0f, 1000.0f, "%.f");
+
+        ImGui.Separator();
+
+        changed = changed || ImGui.Button("Reset Scene");
+
+        if (changed)
+        {
+            b2Joint_SetConstraintTuning(m_jointId1, m_jointHertz, m_jointDampingRatio);
+            b2Joint_SetConstraintTuning(m_jointId2, m_jointHertz, m_jointDampingRatio);
+            CreateScene();
+        }
+
+        ImGui.PopItemWidth();
+        ImGui.End();
+    }
+}

--- a/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
@@ -22,7 +22,7 @@ public class OverlapRecovery : Sample
     private int m_baseCount;
     private float m_overlap;
     private float m_extent;
-    private float m_pushout;
+    private float m_pushOut;
     private float m_hertz;
     private float m_dampingRatio;
 
@@ -36,7 +36,7 @@ public class OverlapRecovery : Sample
         if (m_context.settings.restart == false)
         {
             m_camera.m_center = new B2Vec2(0.0f, 2.5f);
-            m_camera.m_zoom = 25.0f * 0.15f;
+            m_camera.m_zoom = 3.75f;
         }
 
         m_bodyIds = null;
@@ -44,7 +44,7 @@ public class OverlapRecovery : Sample
         m_baseCount = 4;
         m_overlap = 0.25f;
         m_extent = 0.5f;
-        m_pushout = 3.0f;
+        m_pushOut = 3.0f;
         m_hertz = 30.0f;
         m_dampingRatio = 10.0f;
 
@@ -69,7 +69,7 @@ public class OverlapRecovery : Sample
             b2DestroyBody(m_bodyIds[i]);
         }
 
-        b2World_SetContactTuning(m_worldId, m_hertz, m_dampingRatio, m_pushout);
+        b2World_SetContactTuning(m_worldId, m_hertz, m_dampingRatio, m_pushOut);
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
         bodyDef.type = B2BodyType.b2_dynamicBody;
@@ -120,8 +120,8 @@ public class OverlapRecovery : Sample
         changed = changed || ImGui.SliderFloat("Extent", ref m_extent, 0.1f, 1.0f, "%.1f");
         changed = changed || ImGui.SliderInt("Base Count", ref m_baseCount, 1, 10);
         changed = changed || ImGui.SliderFloat("Overlap", ref m_overlap, 0.0f, 1.0f, "%.2f");
-        changed = changed || ImGui.SliderFloat("Pushout", ref m_pushout, 0.0f, 10.0f, "%.1f");
-        changed = changed || ImGui.SliderFloat("Hertz", ref m_hertz, 0.0f, 120.0f, "%.f");
+        changed = changed || ImGui.SliderFloat("Speed", ref m_pushOut, 0.0f, 10.0f, "%.1f");
+        changed = changed || ImGui.SliderFloat("Hertz", ref m_hertz, 0.0f, 240.0f, "%.f");
         changed = changed || ImGui.SliderFloat("Damping Ratio", ref m_dampingRatio, 0.0f, 20.0f, "%.1f");
         changed = changed || ImGui.Button("Reset Scene");
 

--- a/src/Box2D.NET.Samples/Samples/Sample.cs
+++ b/src/Box2D.NET.Samples/Samples/Sample.cs
@@ -27,7 +27,7 @@ public class Sample : IDisposable
     public const int k_maxContactPoints = 12 * 2048;
     public const int m_maxTasks = 64;
     public const int m_maxThreads = 64;
-    
+
 #if DEBUG
     public const bool m_isDebug = true;
 #else
@@ -37,7 +37,7 @@ public class Sample : IDisposable
     protected SampleContext m_context;
     protected Camera m_camera;
     protected Draw m_draw;
-    
+
     protected TaskScheduler m_scheduler;
     protected SampleTask[] m_tasks;
     protected int m_taskCount;
@@ -50,7 +50,7 @@ public class Sample : IDisposable
     protected B2JointId m_mouseJointId;
     protected B2Profile m_maxProfile;
     protected B2Profile m_totalProfile;
-    
+
     private int m_textLine;
     private int m_textIncrement;
 
@@ -59,7 +59,7 @@ public class Sample : IDisposable
         m_context = context;
         m_camera = context.camera;
         m_draw = context.draw;
-        
+
         m_scheduler = new TaskScheduler();
         m_scheduler.Initialize(m_context.settings.workerCount);
 
@@ -301,9 +301,9 @@ public class Sample : IDisposable
                 mouseDef.bodyIdA = m_groundBodyId;
                 mouseDef.bodyIdB = queryContext.bodyId;
                 mouseDef.target = p;
-                mouseDef.hertz = 5.0f;
+                mouseDef.hertz = 10.0f;
                 mouseDef.dampingRatio = 0.7f;
-                mouseDef.maxForce = 1000.0f * b2Body_GetMass(queryContext.bodyId);
+                mouseDef.maxForce = 1000.0f * b2Body_GetMass(queryContext.bodyId) * b2Length(b2World_GetGravity(m_worldId));
                 m_mouseJointId = b2CreateMouseJoint(m_worldId, ref mouseDef);
 
                 b2Body_SetAwake(queryContext.bodyId, true);
@@ -355,7 +355,7 @@ public class Sample : IDisposable
         ImGui.TextColored(new Vector4(230, 153, 153, 255), text);
         ImGui.PopFont();
         ImGui.End();
-        
+
         m_textLine += m_textIncrement;
     }
 
@@ -455,7 +455,6 @@ public class Sample : IDisposable
             if (m_context.draw.m_showUI)
             {
                 DrawTextLine("****PAUSED****");
-                
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
@@ -116,7 +116,7 @@ public class Explosion : Sample
             int count = m_jointIds.Count;
             for (int i = 0; i < count; ++i)
             {
-                b2WeldJoint_SetReferenceAngle(m_jointIds[i], m_referenceAngle);
+                b2Joint_SetReferenceAngle(m_jointIds[i], m_referenceAngle);
             }
         }
 

--- a/src/Box2D.NET/B2Constants.cs
+++ b/src/Box2D.NET/B2Constants.cs
@@ -46,6 +46,13 @@ namespace Box2D.NET
 
         // The time that a body must be still before it will go to sleep. In seconds.
         public const float B2_TIME_TO_SLEEP = 0.5f;
+        
+        // The default joint constraint hertz
+        public const float B2_JOINT_CONSTRAINT_HERTZ = 60.0f;
+
+        // The default joint constraint damping ratio
+        public const float B2_JOINT_CONSTRAINT_DAMPING_RATIO = 2.0f;
+
 
         // collision
         // -----------------------------------------------------------------------------------------------------------------

--- a/src/Box2D.NET/B2ContactSolvers.cs
+++ b/src/Box2D.NET/B2ContactSolvers.cs
@@ -1416,7 +1416,7 @@ static void b2ScatterBodies( b2BodyState* states, int* indices, const b2BodyStat
             B2BodyState[] states = context.states;
             Span<B2ContactConstraintSIMD> constraints = context.graph.colors[colorIndex].simdConstraints;
             B2FloatW inv_h = b2SplatW(context.inv_h);
-            B2FloatW minBiasVel = b2SplatW(-context.world.maxContactPushSpeed);
+            B2FloatW minBiasVel = b2SplatW(-context.world.contactSpeed);
             B2FloatW oneW = b2SplatW(1.0f);
 
             for (int i = startIndex; i < endIndex; ++i)

--- a/src/Box2D.NET/B2DistanceJoints.cs
+++ b/src/Box2D.NET/B2DistanceJoints.cs
@@ -385,9 +385,9 @@ namespace Box2D.NET
                         }
                         else if (useBias)
                         {
-                            bias = context.jointSoftness.biasRate * C;
-                            massCoeff = context.jointSoftness.massScale;
-                            impulseCoeff = context.jointSoftness.impulseScale;
+                            bias = @base.constraintSoftness.biasRate * C;
+                            massCoeff = @base.constraintSoftness.massScale;
+                            impulseCoeff = @base.constraintSoftness.impulseScale;
                         }
 
                         float impulse = -massCoeff * joint.axialMass * (Cdot + bias) - impulseCoeff * joint.lowerImpulse;
@@ -419,9 +419,9 @@ namespace Box2D.NET
                         }
                         else if (useBias)
                         {
-                            bias = context.jointSoftness.biasRate * C;
-                            massScale = context.jointSoftness.massScale;
-                            impulseScale = context.jointSoftness.impulseScale;
+                            bias = @base.constraintSoftness.biasRate * C;
+                            massScale = @base.constraintSoftness.massScale;
+                            impulseScale = @base.constraintSoftness.impulseScale;
                         }
 
                         float impulse = -massScale * joint.axialMass * (Cdot + bias) - impulseScale * joint.upperImpulse;
@@ -467,9 +467,9 @@ namespace Box2D.NET
                 float impulseScale = 0.0f;
                 if (useBias)
                 {
-                    bias = context.jointSoftness.biasRate * C;
-                    massScale = context.jointSoftness.massScale;
-                    impulseScale = context.jointSoftness.impulseScale;
+                    bias = @base.constraintSoftness.biasRate * C;
+                    massScale = @base.constraintSoftness.massScale;
+                    impulseScale = @base.constraintSoftness.impulseScale;
                 }
 
                 float impulse = -massScale * joint.axialMass * (Cdot + bias) - impulseScale * joint.impulse;

--- a/src/Box2D.NET/B2Ids.cs
+++ b/src/Box2D.NET/B2Ids.cs
@@ -81,6 +81,21 @@ namespace Box2D.NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool B2_ID_EQUALS(B2ShapeId id1, B2ShapeId id2) => id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation;
 
+        /// Store a world id into a uint32_t.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint b2StoreWorldId(B2WorldId id)
+        {
+            return ((uint)id.index1 << 16) | (uint)id.generation;
+        }
+
+        /// Load a uint32_t into a world id.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static B2WorldId b2LoadWorldId(uint x)
+        {
+            B2WorldId id = new B2WorldId((ushort)(x >> 16), (ushort)(x));
+            return id;
+        }
+
         /// Store a body id into a ulong.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong b2StoreBodyId(B2BodyId id)

--- a/src/Box2D.NET/B2JointSim.cs
+++ b/src/Box2D.NET/B2JointSim.cs
@@ -23,6 +23,11 @@ namespace Box2D.NET
         public float invIA, invIB;
 
 
+        public float constraintHertz;
+        public float constraintDampingRatio;
+
+        public B2Softness constraintSoftness;
+
         // TODO: @ikpil, check union
         public B2JointUnion uj;
 
@@ -38,6 +43,9 @@ namespace Box2D.NET
             invMassB = 0.0f;
             invIA = 0.0f;
             invIB = 0.0f;
+            constraintHertz = 0.0f;
+            constraintDampingRatio = 0.0f;
+            constraintSoftness = new B2Softness();
             uj = new B2JointUnion();
         }
 
@@ -53,6 +61,9 @@ namespace Box2D.NET
             invMassB = other.invMassB;
             invIA = other.invIA;
             invIB = other.invIB;
+            constraintHertz = other.constraintHertz;
+            constraintDampingRatio = other.constraintDampingRatio;
+            constraintSoftness = other.constraintSoftness;
             uj = other.uj;
         }
     }

--- a/src/Box2D.NET/B2MathFunction.cs
+++ b/src/Box2D.NET/B2MathFunction.cs
@@ -628,6 +628,18 @@ namespace Box2D.NET
             return b2Dot(plane.normal, point) - plane.offset;
         }
 
+        /// One-dimensional mass-spring-damper simulation. Returns the new velocity given the position and time step.
+        /// You can then compute the new position using:
+        /// position += timeStep * newVelocity
+        /// This drives towards a zero position. By using implicit integration we get a stable solution
+        /// that doesn't require transcendental functions.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float b2SpringDamper(float hertz, float dampingRatio, float position, float velocity, float timeStep)
+        {
+            float omega = 2.0f * B2_PI * hertz;
+            float omegaH = omega * timeStep;
+            return (velocity - omega * omegaH * position) / (1.0f + 2.0f * dampingRatio * omegaH + omegaH * omegaH);
+        }
 
         /**@}*/
         //B2_ASSERT( sizeof( int ) == sizeof( int ), "Box2D expects int and int to be the same" );

--- a/src/Box2D.NET/B2Movers.cs
+++ b/src/Box2D.NET/B2Movers.cs
@@ -11,17 +11,17 @@ namespace Box2D.NET
     public static class B2Movers
     {
         /// Solves the position of a mover that satisfies the given collision planes.
-        /// @param position this must be the position used to generate the collision planes
+        /// @param targetDelta the desired movement from the position used to generate the collision planes
         /// @param planes the collision planes
         /// @param count the number of collision planes
-        public static B2PlaneSolverResult b2SolvePlanes(B2Vec2 position, Span<B2CollisionPlane> planes, int count)
+        public static B2PlaneSolverResult b2SolvePlanes(B2Vec2 targetDelta, Span<B2CollisionPlane> planes, int count)
         {
             for (int i = 0; i < count; ++i)
             {
                 planes[i].push = 0.0f;
             }
 
-            B2Vec2 delta = new B2Vec2();
+            B2Vec2 delta = targetDelta;
             float tolerance = B2_LINEAR_SLOP;
 
             int iteration;
@@ -57,7 +57,7 @@ namespace Box2D.NET
                 }
             }
 
-            return new B2PlaneSolverResult(b2Add(delta, position), iteration);
+            return new B2PlaneSolverResult(delta, iteration);
         }
 
         /// Clips the velocity against the given collision planes. Planes with zero push or clipVelocity

--- a/src/Box2D.NET/B2PlaneSolverResult.cs
+++ b/src/Box2D.NET/B2PlaneSolverResult.cs
@@ -7,15 +7,15 @@ namespace Box2D.NET
     /// Result returned by b2SolvePlane
     public struct B2PlaneSolverResult
     {
-        /// The final position of the mover
-        public B2Vec2 position;
+        /// The translation of the mover
+        public B2Vec2 translation;
         
         /// The number of iterations used by the plane solver. For diagnostics.
         public int iterationCount;
 
-        public B2PlaneSolverResult(B2Vec2 position, int iterationCount)
+        public B2PlaneSolverResult(B2Vec2 translation, int iterationCount)
         {
-            this.position = position;
+            this.translation = translation;
             this.iterationCount = iterationCount;
         }
     }

--- a/src/Box2D.NET/B2PrismaticJoints.cs
+++ b/src/Box2D.NET/B2PrismaticJoints.cs
@@ -489,9 +489,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     float oldImpulse = joint.lowerImpulse;
@@ -527,9 +527,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     float oldImpulse = joint.upperImpulse;
@@ -572,9 +572,9 @@ namespace Box2D.NET
                     C.X = b2Dot(perpA, d);
                     C.Y = b2RelativeAngle(stateB.deltaRotation, stateA.deltaRotation) + joint.deltaAngle;
 
-                    bias = b2MulSV(context.jointSoftness.biasRate, C);
-                    massScale = context.jointSoftness.massScale;
-                    impulseScale = context.jointSoftness.impulseScale;
+                    bias = b2MulSV(@base.constraintSoftness.biasRate, C);
+                    massScale = @base.constraintSoftness.massScale;
+                    impulseScale = @base.constraintSoftness.impulseScale;
                 }
 
                 float k11 = mA + mB + iA * s1 * s1 + iB * s2 * s2;

--- a/src/Box2D.NET/B2RevoluteJoints.cs
+++ b/src/Box2D.NET/B2RevoluteJoints.cs
@@ -310,8 +310,10 @@ namespace Box2D.NET
             B2Vec2 vB = stateB.linearVelocity;
             float wB = stateB.angularVelocity;
 
+            B2Rot dqA = stateA.deltaRotation;
+            B2Rot dqB = stateB.deltaRotation;
+
             bool fixedRotation = (iA + iB == 0.0f);
-            // const float maxBias = context.maxBiasVelocity;
 
             // Solve spring.
             if (joint.enableSpring && fixedRotation == false)
@@ -348,8 +350,7 @@ namespace Box2D.NET
 
             if (joint.enableLimit && fixedRotation == false)
             {
-                float jointAngle =
-                    b2RelativeAngle(stateB.deltaRotation, stateA.deltaRotation) + joint.deltaAngle - joint.referenceAngle;
+                float jointAngle = b2RelativeAngle(dqB, dqA) + joint.deltaAngle - joint.referenceAngle;
                 jointAngle = b2UnwindAngle(jointAngle);
 
                 // Lower limit
@@ -365,9 +366,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     float Cdot = wB - wA;
@@ -395,9 +396,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     // sign flipped on Cdot
@@ -435,9 +436,9 @@ namespace Box2D.NET
                     B2Vec2 dcB = stateB.deltaPosition;
 
                     B2Vec2 separation = b2Add(b2Add(b2Sub(dcB, dcA), b2Sub(rB, rA)), joint.deltaCenter);
-                    bias = b2MulSV(context.jointSoftness.biasRate, separation);
-                    massScale = context.jointSoftness.massScale;
-                    impulseScale = context.jointSoftness.impulseScale;
+                    bias = b2MulSV(@base.constraintSoftness.biasRate, separation);
+                    massScale = @base.constraintSoftness.massScale;
+                    impulseScale = @base.constraintSoftness.impulseScale;
                 }
 
                 B2Mat22 K;

--- a/src/Box2D.NET/B2StepContext.cs
+++ b/src/Box2D.NET/B2StepContext.cs
@@ -21,7 +21,6 @@ namespace Box2D.NET
 
         public int subStepCount;
 
-        public B2Softness jointSoftness;
         public B2Softness contactSoftness;
         public B2Softness staticSoftness;
 

--- a/src/Box2D.NET/B2Types.cs
+++ b/src/Box2D.NET/B2Types.cs
@@ -24,8 +24,7 @@ namespace Box2D.NET
             def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
             def.contactHertz = 30.0f;
             def.contactDampingRatio = 10.0f;
-            def.jointHertz = 60.0f;
-            def.jointDampingRatio = 2.0f;
+            
             // 400 meters per second, faster than the speed of sound
             def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
             def.enableSleep = true;

--- a/src/Box2D.NET/B2WeldJoints.cs
+++ b/src/Box2D.NET/B2WeldJoints.cs
@@ -14,19 +14,6 @@ namespace Box2D.NET
 {
     public static class B2WeldJoints
     {
-        public static float b2WeldJoint_GetReferenceAngle(B2JointId jointId)
-        {
-            B2JointSim joint = b2GetJointSimCheckType(jointId, B2JointType.b2_weldJoint);
-            return joint.uj.weldJoint.referenceAngle;
-        }
-
-        public static void b2WeldJoint_SetReferenceAngle(B2JointId jointId, float angleInRadians)
-        {
-            B2_ASSERT(b2IsValidFloat(angleInRadians));
-            B2JointSim joint = b2GetJointSimCheckType(jointId, B2JointType.b2_weldJoint);
-            joint.uj.weldJoint.referenceAngle = b2ClampFloat(angleInRadians, -B2_PI, B2_PI);
-        }
-
         public static void b2WeldJoint_SetLinearHertz(B2JointId jointId, float hertz)
         {
             B2_ASSERT(b2IsValidFloat(hertz) && hertz >= 0.0f);
@@ -155,7 +142,7 @@ namespace Box2D.NET
 
             if (joint.linearHertz == 0.0f)
             {
-                joint.linearSoftness = context.jointSoftness;
+                joint.linearSoftness = @base.constraintSoftness;
             }
             else
             {
@@ -164,7 +151,7 @@ namespace Box2D.NET
 
             if (joint.angularHertz == 0.0f)
             {
-                joint.angularSoftness = context.jointSoftness;
+                joint.angularSoftness = @base.constraintSoftness;
             }
             else
             {

--- a/src/Box2D.NET/B2WheelJoints.cs
+++ b/src/Box2D.NET/B2WheelJoints.cs
@@ -393,9 +393,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     float Cdot = b2Dot(axisA, b2Sub(vB, vA)) + a2 * wB - a1 * wA;
@@ -431,9 +431,9 @@ namespace Box2D.NET
                     }
                     else if (useBias)
                     {
-                        bias = context.jointSoftness.biasRate * C;
-                        massScale = context.jointSoftness.massScale;
-                        impulseScale = context.jointSoftness.impulseScale;
+                        bias = @base.constraintSoftness.biasRate * C;
+                        massScale = @base.constraintSoftness.massScale;
+                        impulseScale = @base.constraintSoftness.impulseScale;
                     }
 
                     // sign flipped on Cdot
@@ -465,9 +465,9 @@ namespace Box2D.NET
                 if (useBias)
                 {
                     float C = b2Dot(perpA, d);
-                    bias = context.jointSoftness.biasRate * C;
-                    massScale = context.jointSoftness.massScale;
-                    impulseScale = context.jointSoftness.impulseScale;
+                    bias = @base.constraintSoftness.biasRate * C;
+                    massScale = @base.constraintSoftness.massScale;
+                    impulseScale = @base.constraintSoftness.impulseScale;
                 }
 
                 float s1 = b2Cross(b2Add(d, rA), perpA);

--- a/src/Box2D.NET/B2World.cs
+++ b/src/Box2D.NET/B2World.cs
@@ -101,10 +101,9 @@ namespace Box2D.NET
         public float restitutionThreshold;
         public float maxLinearSpeed;
         public float maxContactPushSpeed;
+        public float contactSpeed;
         public float contactHertz;
         public float contactDampingRatio;
-        public float jointHertz;
-        public float jointDampingRatio;
 
         public b2FrictionCallback frictionCallback;
         public b2RestitutionCallback restitutionCallback;
@@ -206,10 +205,9 @@ namespace Box2D.NET
             restitutionThreshold = 0.0f;
             maxLinearSpeed = 0.0f;
             maxContactPushSpeed = 0.0f;
+            contactSpeed = 0.0f;
             contactHertz = 0.0f;
             contactDampingRatio = 0.0f;
-            jointHertz = 0.0f;
-            jointDampingRatio = 0.0f;
 
             frictionCallback = null;
             restitutionCallback = null;

--- a/src/Box2D.NET/B2WorldDef.cs
+++ b/src/Box2D.NET/B2WorldDef.cs
@@ -31,12 +31,6 @@ namespace Box2D.NET
         /// decreasing the damping ratio.
         public float maxContactPushSpeed;
 
-        /// Joint stiffness. Cycles per second.
-        public float jointHertz;
-
-        /// Joint bounciness. Non-dimensional.
-        public float jointDampingRatio;
-
         /// Maximum linear speed. Usually meters per second.
         public float maximumLinearSpeed;
 

--- a/test/Box2D.NET.Test/B2DeterminismTest.cs
+++ b/test/Box2D.NET.Test/B2DeterminismTest.cs
@@ -131,8 +131,8 @@ public class b2TaskTester : IDisposable
 
 public class B2DeterminismTest
 {
-    private const int EXPECTED_SLEEP_STEP = 323;
-    private const uint EXPECTED_HASH = 0xdf9ee1fb;
+    private const int EXPECTED_SLEEP_STEP = 288;
+    private const uint EXPECTED_HASH = 0x35467e1e;
 
     private const int e_maxTasks = 128;
 

--- a/test/Box2D.NET.Test/B2IdsTest.cs
+++ b/test/Box2D.NET.Test/B2IdsTest.cs
@@ -79,6 +79,14 @@ public class B2IdsTest
     [Test]
     public void Test_B2Ids_StoreLoad()
     {
+        uint a = 0x01234567;
+
+        {
+            B2WorldId id = b2LoadWorldId(a);
+            uint b = b2StoreWorldId(id);
+            Assert.That(b, Is.EqualTo(a));
+        }
+
         // Test storing and loading IDs
         ulong testValue = 0x0123456789ABCDEFul;
 
@@ -177,4 +185,4 @@ public class B2IdsTest
         var loadedJoint = b2LoadJointId(storedJoint);
         Assert.That(loadedJoint.generation, Is.EqualTo(testGeneration), "Joint ID generation number should be preserved");
     }
-} 
+}

--- a/test/Box2D.NET.Test/B2WorldTest.cs
+++ b/test/Box2D.NET.Test/B2WorldTest.cs
@@ -306,7 +306,6 @@ public class B2WorldTest
         b2World_Explode(worldId, ref explosionDef);
 
         b2World_SetContactTuning(worldId, 10.0f, 2.0f, 4.0f);
-        b2World_SetJointTuning(worldId, 10.0f, 2.0f);
 
         b2World_SetMaximumLinearSpeed(worldId, 10.0f);
         value = b2World_GetMaximumLinearSpeed(worldId);


### PR DESCRIPTION
Joint stiffness is now tunable per joint. This allows specific joints to have increased stiffness, which may be important for some games. Removed `b2World_SetJointTuning`
Added `b2Joint_SetConstraintTuning` and `b2Joint_GetConstraintTuning`. Added `b2StoreWorldId` and `b2LoadWorldId`.
Added `b2Joint_GetReferenceAngle`, `b2Joint_SetReferenceAngle`, `b2Joint_SetLocalAxisA`, and `b2Joint_GetLocalAxisA`. Removed `b2WeldJoint_GetReferenceAngle` and
`b2WeldJoint_SetReferenceAngle`.
Added `b2SpringDamper` math utility function used by the character sample.
Fixed bug in `b2SolvePlanes`.