### PR TITLE
[upstream] Joint events (box2d #942)

### DIFF
--- a/src/Box2D.NET.Samples/Primitives/CustomUserData.cs
+++ b/src/Box2D.NET.Samples/Primitives/CustomUserData.cs
@@ -4,21 +4,21 @@
 
 namespace Box2D.NET.Samples.Primitives;
 
-public static class BodyUserData
+public static class CustomUserData
 {
-    public static BodyUserData<T> Create<T>(T value)
+    public static CustomUserData<T> Create<T>(T value)
     {
-        var userData = new BodyUserData<T>();
+        var userData = new CustomUserData<T>();
         userData.Value = value;
 
         return userData;
     }
 }
-public class BodyUserData<T>
+public class CustomUserData<T>
 {
     public T Value;
 
-    internal BodyUserData()
+    internal CustomUserData()
     {
         
     }

--- a/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
@@ -97,30 +97,29 @@ public class BodyType : Sample
 
             B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
             B2Vec2 pivot = new B2Vec2(-2.0f, 5.0f);
-            revoluteDef.bodyIdA = m_attachmentId;
-            revoluteDef.bodyIdB = m_platformId;
-            revoluteDef.localAnchorA = b2Body_GetLocalPoint(m_attachmentId, pivot);
-            revoluteDef.localAnchorB = b2Body_GetLocalPoint(m_platformId, pivot);
+            revoluteDef.@base.bodyIdA = m_attachmentId;
+            revoluteDef.@base.bodyIdB = m_platformId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(m_attachmentId, pivot);
+            revoluteDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, pivot);
             revoluteDef.maxMotorTorque = 50.0f;
             revoluteDef.enableMotor = true;
             b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
 
             pivot = new B2Vec2(3.0f, 5.0f);
-            revoluteDef.bodyIdA = m_secondAttachmentId;
-            revoluteDef.bodyIdB = m_platformId;
-            revoluteDef.localAnchorA = b2Body_GetLocalPoint(m_secondAttachmentId, pivot);
-            revoluteDef.localAnchorB = b2Body_GetLocalPoint(m_platformId, pivot);
+            revoluteDef.@base.bodyIdA = m_secondAttachmentId;
+            revoluteDef.@base.bodyIdB = m_platformId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(m_secondAttachmentId, pivot);
+            revoluteDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, pivot);
             revoluteDef.maxMotorTorque = 50.0f;
             revoluteDef.enableMotor = true;
             b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
 
             B2PrismaticJointDef prismaticDef = b2DefaultPrismaticJointDef();
             B2Vec2 anchor = new B2Vec2(0.0f, 5.0f);
-            prismaticDef.bodyIdA = groundId;
-            prismaticDef.bodyIdB = m_platformId;
-            prismaticDef.localAnchorA = b2Body_GetLocalPoint(groundId, anchor);
-            prismaticDef.localAnchorB = b2Body_GetLocalPoint(m_platformId, anchor);
-            prismaticDef.localAxisA = new B2Vec2(1.0f, 0.0f);
+            prismaticDef.@base.bodyIdA = groundId;
+            prismaticDef.@base.bodyIdB = m_platformId;
+            prismaticDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, anchor);
+            prismaticDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, anchor);
             prismaticDef.maxMotorForce = 1000.0f;
             prismaticDef.motorSpeed = 0.0f;
             prismaticDef.enableMotor = true;
@@ -128,7 +127,7 @@ public class BodyType : Sample
             prismaticDef.upperTranslation = 10.0f;
             prismaticDef.enableLimit = true;
 
-            b2CreatePrismaticJoint(m_worldId, prismaticDef);
+            b2CreatePrismaticJoint(m_worldId, ref prismaticDef);
 
             m_speed = 3.0f;
         }

--- a/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
@@ -127,10 +127,10 @@ public class Sleep : Sample
 
             B2Vec2 pivot = bodyDef.position;
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_pendulumId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_pendulumId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             b2CreateRevoluteJoint(m_worldId, ref jointDef);
         }
 
@@ -265,7 +265,6 @@ public class Sleep : Sample
         for (int i = 0; i < 2; ++i)
         {
             DrawTextLine($"sensor touch {i} = {m_sensorTouching[i]}");
-            
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Car.cs
+++ b/src/Box2D.NET.Samples/Samples/Car.cs
@@ -83,11 +83,11 @@ public struct Car
 
         B2WheelJointDef jointDef = b2DefaultWheelJointDef();
 
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_rearWheelId;
-        jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-        jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-        jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_rearWheelId;
+        jointDef.@base.localFrameA.q = b2MakeRot(0.5f * B2_PI);
+        jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+        jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
         jointDef.motorSpeed = 0.0f;
         jointDef.maxMotorTorque = torque;
         jointDef.enableMotor = true;
@@ -99,11 +99,11 @@ public struct Car
         m_rearAxleId = b2CreateWheelJoint(worldId, ref jointDef);
 
         pivot = b2Body_GetPosition(m_frontWheelId);
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_frontWheelId;
-        jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-        jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-        jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_frontWheelId;
+        jointDef.@base.localFrameA.q = b2MakeRot(0.5f * B2_PI);
+        jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+        jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
         jointDef.motorSpeed = 0.0f;
         jointDef.maxMotorTorque = torque;
         jointDef.enableMotor = true;

--- a/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
+++ b/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
@@ -200,10 +200,10 @@ public class Mover : Sample
                 b2CreatePolygonShape(bodyId, ref shapeDef, ref box);
 
                 B2Vec2 pivot = new B2Vec2(xBase + 1.0f * i, yBase);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 prevBodyId = bodyId;
@@ -211,10 +211,10 @@ public class Mover : Sample
 
             {
                 B2Vec2 pivot = new B2Vec2(xBase + 1.0f * count, yBase);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = groundId2;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = groundId2;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
             }
         }

--- a/src/Box2D.NET.Samples/Samples/Continuous/Pinball.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/Pinball.cs
@@ -18,7 +18,7 @@ namespace Box2D.NET.Samples.Samples.Continuous;
 public class Pinball : Sample
 {
     private static readonly int SamplePinball = SampleFactory.Shared.RegisterSample("Continuous", "Pinball", Create);
-    
+
     private B2JointId m_leftJointId;
     private B2JointId m_rightJointId;
     private B2BodyId m_ballId;
@@ -82,22 +82,22 @@ public class Pinball : Sample
             b2CreatePolygonShape(rightFlipperId, ref shapeDef, ref box);
 
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.localAnchorB = b2Vec2_zero;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.localFrameB.p = b2Vec2_zero;
             jointDef.enableMotor = true;
             jointDef.maxMotorTorque = 1000.0f;
             jointDef.enableLimit = true;
 
             jointDef.motorSpeed = 0.0f;
-            jointDef.localAnchorA = p1;
-            jointDef.bodyIdB = leftFlipperId;
+            jointDef.@base.localFrameA.p = p1;
+            jointDef.@base.bodyIdB = leftFlipperId;
             jointDef.lowerAngle = -30.0f * B2_PI / 180.0f;
             jointDef.upperAngle = 5.0f * B2_PI / 180.0f;
             m_leftJointId = b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
             jointDef.motorSpeed = 0.0f;
-            jointDef.localAnchorA = p2;
-            jointDef.bodyIdB = rightFlipperId;
+            jointDef.@base.localFrameA.p = p2;
+            jointDef.@base.bodyIdB = rightFlipperId;
             jointDef.lowerAngle = -5.0f * B2_PI / 180.0f;
             jointDef.upperAngle = 30.0f * B2_PI / 180.0f;
             m_rightJointId = b2CreateRevoluteJoint(m_worldId, ref jointDef);
@@ -119,10 +119,10 @@ public class Pinball : Sample
             b2CreatePolygonShape(bodyId, ref shapeDef, ref box2);
 
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = bodyDef.position;
-            jointDef.localAnchorB = b2Vec2_zero;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = bodyDef.position;
+            jointDef.@base.localFrameB.p = b2Vec2_zero;
             jointDef.enableMotor = true;
             jointDef.maxMotorTorque = 0.1f;
             b2CreateRevoluteJoint(m_worldId, ref jointDef);
@@ -131,8 +131,8 @@ public class Pinball : Sample
             bodyId = b2CreateBody(m_worldId, ref bodyDef);
             b2CreatePolygonShape(bodyId, ref shapeDef, ref box1);
             b2CreatePolygonShape(bodyId, ref shapeDef, ref box2);
-            jointDef.localAnchorA = bodyDef.position;
-            jointDef.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = bodyDef.position;
+            jointDef.@base.bodyIdB = bodyId;
             b2CreateRevoluteJoint(m_worldId, ref jointDef);
         }
 

--- a/src/Box2D.NET.Samples/Samples/Donut.cs
+++ b/src/Box2D.NET.Samples/Samples/Donut.cs
@@ -71,19 +71,20 @@ public struct Donut
         B2WeldJointDef weldDef = b2DefaultWeldJointDef();
         weldDef.angularHertz = 5.0f;
         weldDef.angularDampingRatio = 0.0f;
-        weldDef.localAnchorA = new B2Vec2(0.0f, 0.5f * length);
-        weldDef.localAnchorB = new B2Vec2(0.0f, -0.5f * length);
+        weldDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.5f * length);
+        weldDef.@base.localFrameB.p = new B2Vec2(0.0f, -0.5f * length);
+        weldDef.@base.drawSize = 0.5f * scale;
 
         B2BodyId prevBodyId = m_bodyIds[m_sides - 1];
         for (int i = 0; i < m_sides; ++i)
         {
-            weldDef.bodyIdA = prevBodyId;
-            weldDef.bodyIdB = m_bodyIds[i];
-            B2Rot rotA = b2Body_GetRotation(prevBodyId);
-            B2Rot rotB = b2Body_GetRotation(m_bodyIds[i]);
-            weldDef.referenceAngle = b2RelativeAngle(rotB, rotA);
+            weldDef.@base.bodyIdA = prevBodyId;
+            weldDef.@base.bodyIdB = m_bodyIds[i];
+            B2Rot qA = b2Body_GetRotation(prevBodyId);
+            B2Rot qB = b2Body_GetRotation(m_bodyIds[i]);
+            weldDef.@base.localFrameA.q = b2InvMulRot(qA, qB);
             m_jointIds[i] = b2CreateWeldJoint(worldId, ref weldDef);
-            prevBodyId = weldDef.bodyIdB;
+            prevBodyId = weldDef.@base.bodyIdB;
         }
 
         m_isSpawned = true;

--- a/src/Box2D.NET.Samples/Samples/Doohickey.cs
+++ b/src/Box2D.NET.Samples/Samples/Doohickey.cs
@@ -37,7 +37,7 @@ public class Doohickey
 
         B2ShapeDef shapeDef = b2DefaultShapeDef();
         shapeDef.material.rollingResistance = 0.1f;
-        
+
         B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 1.0f * scale);
         B2Capsule capsule = new B2Capsule(new B2Vec2(-3.5f * scale, 0.0f), new B2Vec2(3.5f * scale, 0.0f), 0.15f * scale);
 
@@ -59,28 +59,27 @@ public class Doohickey
 
         B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
 
-        revoluteDef.bodyIdA = m_wheelId1;
-        revoluteDef.bodyIdB = m_barId1;
-        revoluteDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
-        revoluteDef.localAnchorB = new B2Vec2(-3.5f * scale, 0.0f);
+        revoluteDef.@base.bodyIdA = m_wheelId1;
+        revoluteDef.@base.bodyIdB = m_barId1;
+        revoluteDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.0f);
+        revoluteDef.@base.localFrameB.p = new B2Vec2(-3.5f * scale, 0.0f);
         revoluteDef.enableMotor = true;
         revoluteDef.maxMotorTorque = 2.0f * scale;
         b2CreateRevoluteJoint(worldId, ref revoluteDef);
 
-        revoluteDef.bodyIdA = m_wheelId2;
-        revoluteDef.bodyIdB = m_barId2;
-        revoluteDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
-        revoluteDef.localAnchorB = new B2Vec2(3.5f * scale, 0.0f);
+        revoluteDef.@base.bodyIdA = m_wheelId2;
+        revoluteDef.@base.bodyIdB = m_barId2;
+        revoluteDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.0f);
+        revoluteDef.@base.localFrameB.p = new B2Vec2(3.5f * scale, 0.0f);
         revoluteDef.enableMotor = true;
         revoluteDef.maxMotorTorque = 2.0f * scale;
         b2CreateRevoluteJoint(worldId, ref revoluteDef);
 
         B2PrismaticJointDef prismaticDef = b2DefaultPrismaticJointDef();
-        prismaticDef.bodyIdA = m_barId1;
-        prismaticDef.bodyIdB = m_barId2;
-        prismaticDef.localAxisA = new B2Vec2(1.0f, 0.0f);
-        prismaticDef.localAnchorA = new B2Vec2(2.0f * scale, 0.0f);
-        prismaticDef.localAnchorB = new B2Vec2(-2.0f * scale, 0.0f);
+        prismaticDef.@base.bodyIdA = m_barId1;
+        prismaticDef.@base.bodyIdB = m_barId2;
+        prismaticDef.@base.localFrameA.p = new B2Vec2(2.0f * scale, 0.0f);
+        prismaticDef.@base.localFrameB.p = new B2Vec2(-2.0f * scale, 0.0f);
         prismaticDef.lowerTranslation = -2.0f * scale;
         prismaticDef.upperTranslation = 2.0f * scale;
         prismaticDef.enableLimit = true;
@@ -89,7 +88,7 @@ public class Doohickey
         prismaticDef.enableSpring = true;
         prismaticDef.hertz = 1.0f;
         prismaticDef.dampingRatio = 0.5f;
-        b2CreatePrismaticJoint(worldId, prismaticDef);
+        b2CreatePrismaticJoint(worldId, ref prismaticDef);
     }
 
     public void Despawn()

--- a/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
@@ -94,7 +94,7 @@ public class BodyMove : Sample
         {
             bodyDef.position = new B2Vec2(x, y);
             bodyDef.isBullet = (m_count % 12 == 0);
-            bodyDef.userData = BodyUserData.Create(m_count);
+            bodyDef.userData = CustomUserData.Create(m_count);
             m_bodyIds[m_count] = b2CreateBody(m_worldId, ref bodyDef);
             m_sleeping[m_count] = false;
 
@@ -149,7 +149,7 @@ public class BodyMove : Sample
 
             // this shows a somewhat contrived way to track body sleeping
             //B2BodyId bodyId = (B2BodyId)@event.userData; // todo: @ikpil check struct casting
-            var diff = (BodyUserData<int>)@event.userData;
+            var diff = (CustomUserData<int>)@event.userData;
             //ptrdiff_t diff = bodyId - m_bodyIds;
             ref bool sleeping = ref m_sleeping[diff.Value];
 

--- a/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
@@ -31,7 +31,7 @@ public class ContactEvent : Sample
     private B2BodyId m_playerId;
     private B2ShapeId m_coreShapeId;
     private B2BodyId[] m_debrisIds = new B2BodyId[e_count];
-    private BodyUserData<int>[] m_bodyUserData = new BodyUserData<int>[e_count];
+    private CustomUserData<int>[] m_bodyUserData = new CustomUserData<int>[e_count];
     private float m_force;
     private float m_wait;
 
@@ -85,7 +85,7 @@ public class ContactEvent : Sample
         for (int i = 0; i < e_count; ++i)
         {
             m_debrisIds[i] = b2_nullBodyId;
-            m_bodyUserData[i] = BodyUserData.Create(i);
+            m_bodyUserData[i] = CustomUserData.Create(i);
         }
 
         m_wait = 0.5f;
@@ -271,7 +271,7 @@ public class ContactEvent : Sample
 
             if (B2_ID_EQUALS(bodyIdA, m_playerId))
             {
-                BodyUserData<int> userDataB = b2Body_GetUserData(bodyIdB) as BodyUserData<int>;
+                CustomUserData<int> userDataB = b2Body_GetUserData(bodyIdB) as CustomUserData<int>;
                 if (userDataB == null)
                 {
                     if (B2_ID_EQUALS(@event.shapeIdA, m_coreShapeId) == false && destroyCount < e_count)
@@ -306,7 +306,7 @@ public class ContactEvent : Sample
             {
                 // Only expect events for the player
                 B2_ASSERT(B2_ID_EQUALS(bodyIdB, m_playerId));
-                BodyUserData<int> userDataA = b2Body_GetUserData(bodyIdA) as BodyUserData<int>;
+                CustomUserData<int> userDataA = b2Body_GetUserData(bodyIdA) as CustomUserData<int>;
                 if (userDataA == null)
                 {
                     if (B2_ID_EQUALS(@event.shapeIdB, m_coreShapeId) == false && destroyCount < e_count)

--- a/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
@@ -137,10 +137,10 @@ public class SensorFunnel : Sample
                 b2CreatePolygonShape(bodyId, ref shapeDef, ref box);
 
                 B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
-                revoluteDef.bodyIdA = groundId;
-                revoluteDef.bodyIdB = bodyId;
-                revoluteDef.localAnchorA = bodyDef.position;
-                revoluteDef.localAnchorB = b2Vec2_zero;
+                revoluteDef.@base.bodyIdA = groundId;
+                revoluteDef.@base.bodyIdB = bodyId;
+                revoluteDef.@base.localFrameA.p = bodyDef.position;
+                revoluteDef.@base.localFrameB.p = b2Vec2_zero;
                 revoluteDef.maxMotorTorque = 200.0f;
                 revoluteDef.motorSpeed = 2.0f * sign;
                 revoluteDef.enableMotor = true;
@@ -202,7 +202,7 @@ public class SensorFunnel : Sample
         {
             ref Donut donut = ref m_donuts[index];
             // donut->Spawn(m_worldId, center, index + 1, donut);
-            donut.Create(m_worldId, center, 1.0f, 0, true, BodyUserData.Create(index));
+            donut.Create(m_worldId, center, 1.0f, 0, true, CustomUserData.Create(index));
         }
         else
         {
@@ -212,7 +212,7 @@ public class SensorFunnel : Sample
             float jointHertz = 6.0f;
             float jointDamping = 0.5f;
             bool colorize = true;
-            CreateHuman(ref human, m_worldId, center, scale, jointFriction, jointHertz, jointDamping, index + 1, BodyUserData.Create(index), colorize);
+            CreateHuman(ref human, m_worldId, center, scale, jointFriction, jointHertz, jointDamping, index + 1, CustomUserData.Create(index), colorize);
             Human_EnableSensorEvents(ref human, true);
         }
 
@@ -301,7 +301,7 @@ public class SensorFunnel : Sample
 
             if (m_type == (int)ea.e_donut)
             {
-                BodyUserData<int> donut = b2Body_GetUserData(bodyId) as BodyUserData<int>;
+                CustomUserData<int> donut = b2Body_GetUserData(bodyId) as CustomUserData<int>;
                 if (donut != null)
                 {
                     int index = donut.Value;
@@ -313,7 +313,7 @@ public class SensorFunnel : Sample
             }
             else
             {
-                BodyUserData<int> human = b2Body_GetUserData(bodyId) as BodyUserData<int>;
+                CustomUserData<int> human = b2Body_GetUserData(bodyId) as CustomUserData<int>;
                 if (human != null)
                 {
                     int index = human.Value;

--- a/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
@@ -67,10 +67,10 @@ public class BallAndChain : Sample
                 b2CreateCapsuleShape(bodyId, ref shapeDef, ref capsule);
 
                 B2Vec2 pivot = new B2Vec2((2.0f * i) * hx, m_count * hx);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableMotor = true;
                 jointDef.maxMotorTorque = m_frictionTorque;
                 jointDef.enableSpring = i > 0;
@@ -87,16 +87,16 @@ public class BallAndChain : Sample
                 bodyDef.type = B2BodyType.b2_dynamicBody;
                 bodyDef.position = new B2Vec2((1.0f + 2.0f * m_count) * hx + circle.radius - hx, m_count * hx);
                 B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
-                
+
                 shapeDef.filter.categoryBits = 0x2;
                 shapeDef.filter.maskBits = 0x1;
                 b2CreateCircleShape(bodyId, ref shapeDef, ref circle);
 
                 B2Vec2 pivot = new B2Vec2((2.0f * m_count) * hx, m_count * hx);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableMotor = true;
                 jointDef.maxMotorTorque = m_frictionTorque;
                 jointDef.enableSpring = true;

--- a/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
@@ -71,12 +71,12 @@ public class BreakableJoint : Sample
             B2Vec2 pivot1 = new B2Vec2(position.X, position.Y + 1.0f + length);
             B2Vec2 pivot2 = new B2Vec2(position.X, position.Y + 1.0f);
             B2DistanceJointDef jointDef = b2DefaultDistanceJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot1);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot2);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot1);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot2);
             jointDef.length = length;
-            jointDef.collideConnected = true;
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateDistanceJoint(m_worldId, ref jointDef);
         }
 
@@ -92,12 +92,12 @@ public class BreakableJoint : Sample
             b2CreatePolygonShape(bodyId, ref shapeDef, ref box);
 
             B2MotorJointDef jointDef = b2DefaultMotorJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.linearOffset = position;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = position;
             jointDef.maxForce = 1000.0f;
             jointDef.maxTorque = 20.0f;
-            jointDef.collideConnected = true;
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateMotorJoint(m_worldId, ref jointDef);
         }
 
@@ -114,13 +114,12 @@ public class BreakableJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, new B2Vec2(1.0f, 0.0f));
-            jointDef.collideConnected = true;
-            m_jointIds[index] = b2CreatePrismaticJoint(m_worldId, jointDef);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
+            m_jointIds[index] = b2CreatePrismaticJoint(m_worldId, ref jointDef);
         }
 
         position.X += 5.0f;
@@ -136,11 +135,11 @@ public class BreakableJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.collideConnected = true;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
         }
 
@@ -157,15 +156,11 @@ public class BreakableJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2WeldJointDef jointDef = b2DefaultWeldJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.angularHertz = 2.0f;
-            jointDef.angularDampingRatio = 0.5f;
-            jointDef.linearHertz = 2.0f;
-            jointDef.linearDampingRatio = 0.5f;
-            jointDef.collideConnected = true;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateWeldJoint(m_worldId, ref jointDef);
         }
 
@@ -182,11 +177,10 @@ public class BreakableJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2WheelJointDef jointDef = b2DefaultWheelJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, new B2Vec2(1.0f, 0.0f));
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.hertz = 1.0f;
             jointDef.dampingRatio = 0.7f;
             jointDef.lowerTranslation = -1.0f;
@@ -195,7 +189,7 @@ public class BreakableJoint : Sample
             jointDef.enableMotor = true;
             jointDef.maxMotorTorque = 10.0f;
             jointDef.motorSpeed = 1.0f;
-            jointDef.collideConnected = true;
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateWheelJoint(m_worldId, ref jointDef);
         }
 
@@ -261,8 +255,8 @@ public class BreakableJoint : Sample
             B2Vec2 force = b2Joint_GetConstraintForce(m_jointIds[i]);
             if (b2LengthSquared(force) <= m_breakForce * m_breakForce)
             {
-                B2Vec2 point = b2Joint_GetLocalAnchorA(m_jointIds[i]);
-                m_draw.DrawString(point, $"({force.X:F1}, {force.Y:F1})");
+                B2Transform localFrame = b2Joint_GetLocalFrameA(m_jointIds[i]);
+                m_draw.DrawString(localFrame.p, $"({force.X:F1}, {force.Y:F1})");
             }
         }
     }

--- a/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
@@ -20,7 +20,7 @@ namespace Box2D.NET.Samples.Samples.Joints;
 public class Bridge : Sample
 {
     private static readonly int SampleBridgeIndex = SampleFactory.Shared.RegisterSample("Joints", "Bridge", Create);
-    
+
     public const int m_count = 160;
 
     private B2BodyId[] m_bodyIds = new B2BodyId[m_count];
@@ -57,7 +57,7 @@ public class Bridge : Sample
             m_springDampingRatio = 0.7f;
             m_frictionTorque = 200.0f;
 
-            B2Polygon box = b2MakeBox( 0.5f, 0.125f );
+            B2Polygon box = b2MakeBox(0.5f, 0.125f);
 
             B2ShapeDef shapeDef = b2DefaultShapeDef();
             shapeDef.density = 20.0f;
@@ -85,10 +85,10 @@ public class Bridge : Sample
                 b2CreatePolygonShape(m_bodyIds[i], ref shapeDef, ref box);
 
                 B2Vec2 pivot = new B2Vec2(xbase + 1.0f * i, 20.0f);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = m_bodyIds[i];
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = m_bodyIds[i];
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 m_jointIds[jointIndex++] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 prevBodyId = m_bodyIds[i];
@@ -96,10 +96,10 @@ public class Bridge : Sample
 
             {
                 B2Vec2 pivot = new B2Vec2(xbase + 1.0f * m_count, 20.0f);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = groundId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = groundId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 m_jointIds[jointIndex++] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 B2_ASSERT(jointIndex == m_count + 1);
@@ -141,7 +141,7 @@ public class Bridge : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
         float height = 180.0f;
         ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(320.0f, height));
@@ -158,35 +158,35 @@ public class Bridge : Sample
             }
         }
 
-        if ( ImGui.SliderFloat( "Spring hertz", ref m_springHertz, 0.0f, 30.0f, "%.0f" ) )
+        if (ImGui.SliderFloat("Spring hertz", ref m_springHertz, 0.0f, 30.0f, "%.0f"))
         {
-            for ( int i = 0; i <= m_count; ++i )
+            for (int i = 0; i <= m_count; ++i)
             {
-                b2RevoluteJoint_SetSpringHertz( m_jointIds[i], m_springHertz );
+                b2RevoluteJoint_SetSpringHertz(m_jointIds[i], m_springHertz);
             }
         }
 
-        if ( ImGui.SliderFloat( "Spring damping", ref m_springDampingRatio, 0.0f, 2.0f, "%.1f" ) )
+        if (ImGui.SliderFloat("Spring damping", ref m_springDampingRatio, 0.0f, 2.0f, "%.1f"))
         {
-            for ( int i = 0; i <= m_count; ++i )
+            for (int i = 0; i <= m_count; ++i)
             {
-                b2RevoluteJoint_SetSpringDampingRatio( m_jointIds[i], m_springDampingRatio );
+                b2RevoluteJoint_SetSpringDampingRatio(m_jointIds[i], m_springDampingRatio);
             }
         }
 
-        if ( ImGui.SliderFloat( "Constraint hertz", ref m_constraintHertz, 15.0f, 240.0f, "%.0f" ) )
+        if (ImGui.SliderFloat("Constraint hertz", ref m_constraintHertz, 15.0f, 240.0f, "%.0f"))
         {
-            for ( int i = 0; i <= m_count; ++i )
+            for (int i = 0; i <= m_count; ++i)
             {
-                b2Joint_SetConstraintTuning( m_jointIds[i], m_constraintHertz, m_constraintDampingRatio );
+                b2Joint_SetConstraintTuning(m_jointIds[i], m_constraintHertz, m_constraintDampingRatio);
             }
         }
 
-        if ( ImGui.SliderFloat( "Constraint damping", ref m_constraintDampingRatio, 0.0f, 10.0f, "%.1f" ) )
+        if (ImGui.SliderFloat("Constraint damping", ref m_constraintDampingRatio, 0.0f, 10.0f, "%.1f"))
         {
-            for ( int i = 0; i <= m_count; ++i )
+            for (int i = 0; i <= m_count; ++i)
             {
-                b2Joint_SetConstraintTuning( m_jointIds[i], m_constraintHertz, m_constraintDampingRatio );
+                b2Joint_SetConstraintTuning(m_jointIds[i], m_constraintHertz, m_constraintDampingRatio);
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
@@ -79,16 +79,19 @@ public class Cantilever : Sample
                 b2CreateCapsuleShape(m_bodyIds[i], ref shapeDef, ref capsule);
 
                 B2Vec2 pivot = new B2Vec2((2.0f * i) * hx, 0.0f);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = m_bodyIds[i];
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = m_bodyIds[i];
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.linearHertz = m_linearHertz;
                 jointDef.linearDampingRatio = m_linearDampingRatio;
                 jointDef.angularHertz = m_angularHertz;
                 jointDef.angularDampingRatio = m_angularDampingRatio;
-                jointDef.collideConnected = m_collideConnected;
+                jointDef.@base.collideConnected = m_collideConnected;
                 m_jointIds[i] = b2CreateWeldJoint(m_worldId, ref jointDef);
+
+                // Experimental tuning
+                b2Joint_SetConstraintTuning(m_jointIds[i], 120.0f, 10.0f);
 
                 prevBodyId = m_bodyIds[i];
             }
@@ -167,6 +170,5 @@ public class Cantilever : Sample
 
         B2Vec2 tipPosition = b2Body_GetPosition(m_tipId);
         DrawTextLine($"tip-y = {tipPosition.Y:F2}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
@@ -114,10 +114,10 @@ public class DistanceJoint : Sample
 
             B2Vec2 pivotA = new B2Vec2(m_length * i, yOffset);
             B2Vec2 pivotB = new B2Vec2(m_length * (i + 1.0f), yOffset);
-            jointDef.bodyIdA = prevBodyId;
-            jointDef.bodyIdB = m_bodyIds[i];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivotA);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivotB);
+            jointDef.@base.bodyIdA = prevBodyId;
+            jointDef.@base.bodyIdB = m_bodyIds[i];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivotA);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivotB);
             m_jointIds[i] = b2CreateDistanceJoint(m_worldId, ref jointDef);
 
             prevBodyId = m_bodyIds[i];

--- a/src/Box2D.NET.Samples/Samples/Joints/Door.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Door.cs
@@ -69,10 +69,10 @@ public class Door : Sample
             b2CreatePolygonShape(m_doorId, ref shapeDef, ref box);
 
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_doorId;
-            jointDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
-            jointDef.localAnchorB = new B2Vec2(0.0f, -1.5f);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_doorId;
+            jointDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.0f);
+            jointDef.@base.localFrameB.p = new B2Vec2(0.0f, -1.5f);
             jointDef.targetAngle = 0.0f;
             jointDef.enableSpring = true;
             jointDef.hertz = 1.0f;
@@ -80,7 +80,6 @@ public class Door : Sample
             jointDef.motorSpeed = 0.0f;
             jointDef.maxMotorTorque = 0.0f;
             jointDef.enableMotor = false;
-            jointDef.referenceAngle = 0.0f;
             jointDef.lowerAngle = -0.5f * B2_PI;
             jointDef.upperAngle = 0.5f * B2_PI;
             jointDef.enableLimit = m_enableLimit;
@@ -112,16 +111,16 @@ public class Door : Sample
             b2RevoluteJoint_EnableLimit(m_jointId, m_enableLimit);
         }
 
-        if ( ImGui.SliderFloat( "hertz", ref m_jointHertz, 15.0f, 480.0f, "%.0f" ) )
+        if (ImGui.SliderFloat("hertz", ref m_jointHertz, 15.0f, 480.0f, "%.0f"))
         {
-            b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
+            b2Joint_SetConstraintTuning(m_jointId, m_jointHertz, m_jointDampingRatio);
         }
 
-        if ( ImGui.SliderFloat( "damping", ref m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
+        if (ImGui.SliderFloat("damping", ref m_jointDampingRatio, 0.0f, 10.0f, "%.1f"))
         {
-            b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
+            b2Joint_SetConstraintTuning(m_jointId, m_jointHertz, m_jointDampingRatio);
         }
-        
+
         ImGui.End();
     }
 
@@ -131,8 +130,6 @@ public class Door : Sample
 
         B2Vec2 p = b2Body_GetWorldPoint(m_doorId, new B2Vec2(0.0f, 1.5f));
         m_draw.DrawPoint(p, 5.0f, B2HexColor.b2_colorDarkKhaki);
-
-        m_draw.DrawTransform(b2Transform_identity);
 
         float translationError = b2Joint_GetLinearSeparation(m_jointId);
         m_translationError = b2MaxFloat(m_translationError, translationError);

--- a/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
@@ -116,10 +116,10 @@ public class Driving : Sample
 
             B2Vec2 pivot = bodyDef.position;
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.lowerAngle = -8.0f * B2_PI / 180.0f;
             jointDef.upperAngle = 8.0f * B2_PI / 180.0f;
             jointDef.enableLimit = true;
@@ -144,10 +144,10 @@ public class Driving : Sample
                 b2CreateCapsuleShape(bodyId, ref shapeDef, ref capsule);
 
                 B2Vec2 pivot = new B2Vec2(160.0f + 2.0f * i, -0.125f);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 prevBodyId = bodyId;
@@ -155,10 +155,10 @@ public class Driving : Sample
 
             {
                 B2Vec2 pivot = new B2Vec2(160.0f + 2.0f * N, -0.125f);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = groundId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = groundId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableMotor = true;
                 jointDef.maxMotorTorque = 50.0f;
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
@@ -275,12 +275,12 @@ public class Driving : Sample
         base.Draw(settings);
 
         DrawTextLine("Keys: left = a, brake = s, right = d");
-        
+
 
         B2Vec2 linearVelocity = b2Body_GetLinearVelocity(m_car.m_chassisId);
         float kph = linearVelocity.X * 3.6f;
         DrawTextLine($"speed in kph: {kph:G2}");
-        
+
 
         B2Vec2 carPosition = b2Body_GetPosition(m_car.m_chassisId);
         m_camera.m_center.X = carPosition.X;

--- a/src/Box2D.NET.Samples/Samples/Joints/FilterJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/FilterJoint.cs
@@ -53,8 +53,8 @@ public class FilterJoint : Sample
             b2CreatePolygonShape(bodyId2, ref shapeDef, ref box);
 
             b2FilterJointDef jointDef = b2DefaultFilterJointDef();
-            jointDef.bodyIdA = bodyId1;
-            jointDef.bodyIdB = bodyId2;
+            jointDef.@base.bodyIdA = bodyId1;
+            jointDef.@base.bodyIdB = bodyId2;
 
             b2CreateFilterJoint(m_worldId, ref jointDef);
         }

--- a/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
@@ -38,6 +38,7 @@ public class GearLift : Sample
         {
             m_camera.m_center = new B2Vec2(0.0f, 6.0f);
             m_camera.m_zoom = 7.0f;
+            m_context.settings.drawJoints = false;
         }
 
         B2BodyId groundId;
@@ -120,10 +121,10 @@ public class GearLift : Sample
             m_motorSpeed = 0.0f;
             m_enableMotor = true;
 
-            revoluteDef.bodyIdA = groundId;
-            revoluteDef.bodyIdB = bodyId;
-            revoluteDef.localAnchorA = b2Body_GetLocalPoint(groundId, position);
-            revoluteDef.localAnchorB = b2Vec2_zero;
+            revoluteDef.@base.bodyIdA = groundId;
+            revoluteDef.@base.bodyIdB = bodyId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, position);
+            revoluteDef.@base.localFrameB.p = b2Vec2_zero;
             revoluteDef.enableMotor = m_enableMotor;
             revoluteDef.maxMotorTorque = m_motorTorque;
             revoluteDef.motorSpeed = m_motorSpeed;
@@ -164,13 +165,13 @@ public class GearLift : Sample
 
             B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
 
-            revoluteDef.bodyIdA = groundId;
-            revoluteDef.bodyIdB = followerId;
-            revoluteDef.localAnchorA = b2Body_GetLocalPoint(groundId, position);
-            revoluteDef.localAnchorB = b2Vec2_zero;
+            revoluteDef.@base.bodyIdA = groundId;
+            revoluteDef.@base.bodyIdB = followerId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, position);
+            revoluteDef.@base.localFrameA.q = b2MakeRot(0.25f * B2_PI);
+            revoluteDef.@base.localFrameB.p = b2Vec2_zero;
             revoluteDef.enableMotor = true;
             revoluteDef.maxMotorTorque = 0.5f;
-            revoluteDef.referenceAngle = 0.25f * B2_PI;
             revoluteDef.lowerAngle = -0.3f * B2_PI;
             revoluteDef.upperAngle = 0.8f * B2_PI;
             revoluteDef.enableLimit = true;
@@ -203,10 +204,11 @@ public class GearLift : Sample
                 b2CreateCapsuleShape(bodyId, ref shapeDef, ref capsule);
 
                 B2Vec2 pivot = new B2Vec2(position.X, position.Y + linkHalfLength);
-                jointDef.bodyIdA = prevBodyId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = prevBodyId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+                jointDef.@base.drawSize = 0.2f;
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 position.Y -= 2.0f * linkHalfLength;
@@ -232,26 +234,28 @@ public class GearLift : Sample
             {
                 B2Vec2 pivot = doorPosition + new B2Vec2(0.0f, doorHalfHeight);
                 B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
-                revoluteDef.bodyIdA = lastLinkId;
-                revoluteDef.bodyIdB = bodyId;
-                revoluteDef.localAnchorA = b2Body_GetLocalPoint(lastLinkId, pivot);
-                revoluteDef.localAnchorB = new B2Vec2(0.0f, doorHalfHeight);
+                revoluteDef.@base.bodyIdA = lastLinkId;
+                revoluteDef.@base.bodyIdB = bodyId;
+                revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(lastLinkId, pivot);
+                revoluteDef.@base.localFrameB.p = new B2Vec2(0.0f, doorHalfHeight);
                 revoluteDef.enableMotor = true;
                 revoluteDef.maxMotorTorque = 0.05f;
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
             }
 
             {
+                B2Vec2 localAxis = new B2Vec2(0.0f, 1.0f);
                 B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
-                jointDef.bodyIdA = groundId;
-                jointDef.bodyIdB = bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(groundId, doorPosition);
-                jointDef.localAnchorB = b2Vec2_zero;
-                jointDef.localAxisA = new B2Vec2(0.0f, 1.0f);
+                jointDef.@base.bodyIdA = groundId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, doorPosition);
+                jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector(localAxis);
+                jointDef.@base.localFrameB.p = b2Vec2_zero;
+                jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector(localAxis);
                 jointDef.maxMotorForce = 0.2f;
                 jointDef.enableMotor = true;
-                jointDef.collideConnected = true;
-                b2CreatePrismaticJoint(m_worldId, jointDef);
+                jointDef.@base.collideConnected = true;
+                b2CreatePrismaticJoint(m_worldId, ref jointDef);
             }
         }
 

--- a/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
@@ -69,12 +69,12 @@ public class JointSeparation : Sample
             B2Vec2 pivot1 = new B2Vec2(position.X, position.Y + 1.0f + length);
             B2Vec2 pivot2 = new B2Vec2(position.X, position.Y + 1.0f);
             B2DistanceJointDef jointDef = b2DefaultDistanceJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyIds[index];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot1);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot2);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyIds[index];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot1);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot2);
             jointDef.length = length;
-            jointDef.collideConnected = true;
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateDistanceJoint(m_worldId, ref jointDef);
         }
 
@@ -91,13 +91,12 @@ public class JointSeparation : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyIds[index];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, new B2Vec2(1.0f, 0.0f));
-            jointDef.collideConnected = true;
-            m_jointIds[index] = b2CreatePrismaticJoint(m_worldId, jointDef);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyIds[index];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
+            m_jointIds[index] = b2CreatePrismaticJoint(m_worldId, ref jointDef);
         }
 
         position.X += 10.0f;
@@ -113,11 +112,11 @@ public class JointSeparation : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyIds[index];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.collideConnected = true;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyIds[index];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateRevoluteJoint(m_worldId, ref jointDef);
         }
 
@@ -134,11 +133,11 @@ public class JointSeparation : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2WeldJointDef jointDef = b2DefaultWeldJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyIds[index];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.collideConnected = true;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyIds[index];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateWeldJoint(m_worldId, ref jointDef);
         }
 
@@ -155,11 +154,10 @@ public class JointSeparation : Sample
 
             B2Vec2 pivot = new B2Vec2(position.X - 1.0f, position.Y);
             B2WheelJointDef jointDef = b2DefaultWheelJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyIds[index];
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, new B2Vec2(1.0f, 0.0f));
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyIds[index];
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.hertz = 1.0f;
             jointDef.dampingRatio = 0.7f;
             jointDef.lowerTranslation = -1.0f;
@@ -168,7 +166,7 @@ public class JointSeparation : Sample
             jointDef.enableMotor = true;
             jointDef.maxMotorTorque = 10.0f;
             jointDef.motorSpeed = 1.0f;
-            jointDef.collideConnected = true;
+            jointDef.@base.collideConnected = true;
             m_jointIds[index] = b2CreateWheelJoint(m_worldId, ref jointDef);
         }
 
@@ -234,8 +232,8 @@ public class JointSeparation : Sample
 
             float linear = b2Joint_GetLinearSeparation(m_jointIds[i]);
             float angular = b2Joint_GetAngularSeparation(m_jointIds[i]);
-            B2Vec2 point = b2Joint_GetLocalAnchorA(m_jointIds[i]);
-            m_draw.DrawString(point, $"{linear:F2} m, {180.0f * angular / B2_PI:F1} deg");
+            B2Transform localFrame = b2Joint_GetLocalFrameA(m_jointIds[i]);
+            m_draw.DrawString(localFrame.p, $"{linear:F2} m, {180.0f * angular / B2_PI:F1} deg");
         }
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
@@ -73,8 +73,8 @@ public class MotorJoint : Sample
             m_correctionFactor = 0.3f;
 
             B2MotorJointDef jointDef = b2DefaultMotorJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = m_bodyId;
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_bodyId;
             jointDef.maxForce = m_maxForce;
             jointDef.maxTorque = m_maxTorque;
             jointDef.correctionFactor = m_correctionFactor;
@@ -138,10 +138,8 @@ public class MotorJoint : Sample
 
         float angularOffset = 2.0f * m_time;
 
-        b2MotorJoint_SetLinearOffset(m_jointId, linearOffset);
-        b2MotorJoint_SetAngularOffset(m_jointId, angularOffset);
-
         _transform = new B2Transform(linearOffset, b2MakeRot(angularOffset));
+        b2Joint_SetLocalFrameA(m_jointId, _transform);
 
         base.Step();
     }

--- a/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
@@ -70,11 +70,13 @@ public class PrismaticJoint : Sample
             // B2Vec2 axis = b2Normalize({1.0f, 0.0f});
             B2Vec2 axis = b2Normalize(new B2Vec2(1.0f, 1.0f));
             B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
+            jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector( axis );
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
+            jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector( axis );
+            jointDef.@base.drawSize = 2.0f;
             jointDef.motorSpeed = m_motorSpeed;
             jointDef.maxMotorForce = m_motorForce;
             jointDef.enableMotor = m_enableMotor;
@@ -85,7 +87,7 @@ public class PrismaticJoint : Sample
             jointDef.hertz = m_hertz;
             jointDef.dampingRatio = m_dampingRatio;
 
-            m_jointId = b2CreatePrismaticJoint(m_worldId, jointDef);
+            m_jointId = b2CreatePrismaticJoint(m_worldId, ref jointDef);
         }
     }
 
@@ -146,7 +148,7 @@ public class PrismaticJoint : Sample
                 b2Joint_WakeBodies(m_jointId);
             }
 
-            if (ImGui.SliderFloat("Translation", ref m_translation, -5.0f, 5.0f, "%.1f"))
+            if (ImGui.SliderFloat("Translation", ref m_translation, -15.0f, 15.0f, "%.1f"))
             {
                 b2PrismaticJoint_SetTargetTranslation(m_jointId, m_translation);
                 b2Joint_WakeBodies(m_jointId);

--- a/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
@@ -57,7 +57,7 @@ public class RevoluteJoint : Sample
         }
 
         m_enableSpring = false;
-        m_enableLimit = true;
+        m_enableLimit = false;
         m_enableMotor = false;
         m_hertz = 2.0f;
         m_dampingRatio = 0.5f;
@@ -79,10 +79,11 @@ public class RevoluteJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(-10.0f, 20.5f);
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.q = b2MakeRot( 0.5f * B2_PI );
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
             jointDef.targetAngle = B2_PI * m_targetDegrees / 180.0f;
             jointDef.enableSpring = m_enableSpring;
             jointDef.hertz = m_hertz;
@@ -90,12 +91,13 @@ public class RevoluteJoint : Sample
             jointDef.motorSpeed = m_motorSpeed;
             jointDef.maxMotorTorque = m_motorTorque;
             jointDef.enableMotor = m_enableMotor;
-            jointDef.referenceAngle = 0.5f * B2_PI;
             jointDef.lowerAngle = -0.5f * B2_PI;
             jointDef.upperAngle = 0.75f * B2_PI;
             jointDef.enableLimit = m_enableLimit;
 
             m_jointId1 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
+            
+            b2Joint_SetConstraintTuning( m_jointId1, 120.0f, 0.0f );
         }
 
         {
@@ -126,12 +128,12 @@ public class RevoluteJoint : Sample
 
             B2Vec2 pivot = new B2Vec2(19.0f, 10.0f);
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = body;
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = body;
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
             jointDef.lowerAngle = -0.25f * B2_PI;
-            jointDef.upperAngle = 0.1f * B2_PI;
+            jointDef.upperAngle = 0.0f * B2_PI;
             jointDef.enableLimit = true;
             jointDef.enableMotor = true;
             jointDef.motorSpeed = 0.0f;
@@ -220,8 +222,7 @@ public class RevoluteJoint : Sample
         float torque1 = b2RevoluteJoint_GetMotorTorque(m_jointId1);
         DrawTextLine($"Motor Torque 1 = {torque1:F1}");
 
-
-        float torque2 = b2RevoluteJoint_GetMotorTorque(m_jointId2);
-        DrawTextLine($"Motor Torque 2 = {torque2:F1}");
+        // float torque2 = b2RevoluteJoint_GetMotorTorque(m_jointId2);
+        // DrawTextLine($"Motor Torque 2 = {torque2:F1}");
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
@@ -88,11 +88,11 @@ public class ScissorLift : Sample
                 B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
 
                 // left pin
-                revoluteDef.bodyIdA = baseId1;
-                revoluteDef.bodyIdB = bodyId1;
-                revoluteDef.localAnchorA = baseAnchor1;
-                revoluteDef.localAnchorB = new B2Vec2(-2.5f, 0.0f);
-                revoluteDef.collideConnected = (i == 0) ? true : false;
+                revoluteDef.@base.bodyIdA = baseId1;
+                revoluteDef.@base.bodyIdB = bodyId1;
+                revoluteDef.@base.localFrameA.p = baseAnchor1;
+                revoluteDef.@base.localFrameB.p = new B2Vec2(-2.5f, 0.0f);
+                revoluteDef.@base.collideConnected = (i == 0) ? true : false;
 
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
 
@@ -100,33 +100,32 @@ public class ScissorLift : Sample
                 if (i == 0)
                 {
                     B2WheelJointDef wheelDef = b2DefaultWheelJointDef();
-                    wheelDef.bodyIdA = baseId2;
-                    wheelDef.bodyIdB = bodyId2;
-                    wheelDef.localAxisA = new B2Vec2(1.0f, 0.0f);
-                    wheelDef.localAnchorA = baseAnchor2;
-                    wheelDef.localAnchorB = new B2Vec2(2.5f, 0.0f);
+                    wheelDef.@base.bodyIdA = baseId2;
+                    wheelDef.@base.bodyIdB = bodyId2;
+                    wheelDef.@base.localFrameA.p = baseAnchor2;
+                    wheelDef.@base.localFrameB.p = new B2Vec2(2.5f, 0.0f);
                     wheelDef.enableSpring = false;
-                    wheelDef.collideConnected = true;
+                    wheelDef.@base.collideConnected = true;
 
                     b2CreateWheelJoint(m_worldId, ref wheelDef);
                 }
                 else
                 {
-                    revoluteDef.bodyIdA = baseId2;
-                    revoluteDef.bodyIdB = bodyId2;
-                    revoluteDef.localAnchorA = baseAnchor2;
-                    revoluteDef.localAnchorB = new B2Vec2(2.5f, 0.0f);
-                    revoluteDef.collideConnected = false;
+                    revoluteDef.@base.bodyIdA = baseId2;
+                    revoluteDef.@base.bodyIdB = bodyId2;
+                    revoluteDef.@base.localFrameA.p = baseAnchor2;
+                    revoluteDef.@base.localFrameB.p = new B2Vec2(2.5f, 0.0f);
+                    revoluteDef.@base.collideConnected = false;
 
                     b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
                 }
 
                 // middle pin
-                revoluteDef.bodyIdA = bodyId1;
-                revoluteDef.bodyIdB = bodyId2;
-                revoluteDef.localAnchorA = new B2Vec2(0.0f, 0.0f);
-                revoluteDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
-                revoluteDef.collideConnected = false;
+                revoluteDef.@base.bodyIdA = bodyId1;
+                revoluteDef.@base.bodyIdB = bodyId2;
+                revoluteDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.0f);
+                revoluteDef.@base.localFrameB.p = new B2Vec2(0.0f, 0.0f);
+                revoluteDef.@base.collideConnected = false;
 
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
 
@@ -147,24 +146,23 @@ public class ScissorLift : Sample
             // left pin
             {
                 B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
-                revoluteDef.bodyIdA = platformId;
-                revoluteDef.bodyIdB = baseId1;
-                revoluteDef.localAnchorA = new B2Vec2(-2.5f, -0.4f);
-                revoluteDef.localAnchorB = baseAnchor1;
-                revoluteDef.collideConnected = true;
+                revoluteDef.@base.bodyIdA = platformId;
+                revoluteDef.@base.bodyIdB = baseId1;
+                revoluteDef.@base.localFrameA.p = new B2Vec2(-2.5f, -0.4f);
+                revoluteDef.@base.localFrameB.p = baseAnchor1;
+                revoluteDef.@base.collideConnected = true;
                 b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
             }
 
             // right pin
             {
                 B2WheelJointDef wheelDef = b2DefaultWheelJointDef();
-                wheelDef.bodyIdA = platformId;
-                wheelDef.bodyIdB = baseId2;
-                wheelDef.localAxisA = new B2Vec2(1.0f, 0.0f);
-                wheelDef.localAnchorA = new B2Vec2(2.5f, -0.4f);
-                wheelDef.localAnchorB = baseAnchor2;
+                wheelDef.@base.bodyIdA = platformId;
+                wheelDef.@base.bodyIdB = baseId2;
+                wheelDef.@base.localFrameA.p = new B2Vec2(2.5f, -0.4f);
+                wheelDef.@base.localFrameB.p = baseAnchor2;
                 wheelDef.enableSpring = false;
-                wheelDef.collideConnected = true;
+                wheelDef.@base.collideConnected = true;
                 b2CreateWheelJoint(m_worldId, ref wheelDef);
             }
 
@@ -173,10 +171,10 @@ public class ScissorLift : Sample
             m_motorForce = 2000.0f;
 
             B2DistanceJointDef distanceDef = b2DefaultDistanceJointDef();
-            distanceDef.bodyIdA = groundId;
-            distanceDef.bodyIdB = linkId1;
-            distanceDef.localAnchorA = new B2Vec2(-2.5f, 0.2f);
-            distanceDef.localAnchorB = new B2Vec2(0.5f, 0.0f);
+            distanceDef.@base.bodyIdA = groundId;
+            distanceDef.@base.bodyIdB = linkId1;
+            distanceDef.@base.localFrameA.p = new B2Vec2(-2.5f, 0.2f);
+            distanceDef.@base.localFrameB.p = new B2Vec2(0.5f, 0.0f);
             distanceDef.enableSpring = true;
             distanceDef.minLength = 0.2f;
             distanceDef.maxLength = 5.5f;

--- a/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
@@ -16,7 +16,7 @@ namespace Box2D.NET.Samples.Samples.Joints;
 public class WheelJoint : Sample
 {
     private static readonly int SampleWheel = SampleFactory.Shared.RegisterSample("Joints", "Wheel", Create);
-    
+
     private B2JointId m_jointId;
     private float m_hertz;
     private float m_dampingRatio;
@@ -67,11 +67,11 @@ public class WheelJoint : Sample
             B2Vec2 pivot = new B2Vec2(0.0f, 10.0f);
             B2Vec2 axis = b2Normalize(new B2Vec2(1.0f, 1.0f));
             B2WheelJointDef jointDef = b2DefaultWheelJointDef();
-            jointDef.bodyIdA = groundId;
-            jointDef.bodyIdB = bodyId;
-            jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-            jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-            jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = bodyId;
+            jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector(axis);
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.motorSpeed = m_motorSpeed;
             jointDef.maxMotorTorque = m_motorTorque;
             jointDef.enableMotor = m_enableMotor;
@@ -88,7 +88,7 @@ public class WheelJoint : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
         float height = 220.0f;
         ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
@@ -142,9 +142,8 @@ public class WheelJoint : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         float torque = b2WheelJoint_GetMotorTorque(m_jointId);
         DrawTextLine($"Motor Torque = {torque,4:F1}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
@@ -117,18 +117,18 @@ public class Cart : Sample
         b2CreateCircleShape(m_wheelId2, ref shapeDef, ref circle);
 
         B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_wheelId1;
-        jointDef.localAnchorA = new B2Vec2(-0.4f, -0.15f);
-        jointDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_wheelId1;
+        jointDef.@base.localFrameA.p = new B2Vec2(-0.4f, -0.15f);
+        jointDef.@base.localFrameB.p = new B2Vec2(0.0f, 0.0f);
 
         m_jointId1 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
         b2Joint_SetConstraintTuning(m_jointId1, m_jointHertz, m_jointDampingRatio);
 
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_wheelId2;
-        jointDef.localAnchorA = new B2Vec2(0.4f, -0.15f);
-        jointDef.localAnchorB = new B2Vec2(0.0f, 0.0f);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_wheelId2;
+        jointDef.@base.localFrameA.p = new B2Vec2(0.4f, -0.15f);
+        jointDef.@base.localFrameB.p = new B2Vec2(0.0f, 0.0f);
 
         m_jointId2 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
         b2Joint_SetConstraintTuning(m_jointId2, m_jointHertz, m_jointDampingRatio);

--- a/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
@@ -50,13 +50,13 @@ public class Explosion : Sample
         m_referenceAngle = 0.0f;
 
         B2WeldJointDef weldDef = b2DefaultWeldJointDef();
-        weldDef.referenceAngle = m_referenceAngle;
+        weldDef.@base.bodyIdA = groundId;
+        weldDef.@base.localFrameA.q = b2MakeRot(m_referenceAngle);
+        weldDef.@base.localFrameB.p = b2Vec2_zero;
         weldDef.angularHertz = 0.5f;
         weldDef.angularDampingRatio = 0.7f;
         weldDef.linearHertz = 0.5f;
         weldDef.linearDampingRatio = 0.7f;
-        weldDef.bodyIdA = groundId;
-        weldDef.localAnchorB = b2Vec2_zero;
 
         float r = 8.0f;
         for (float angle = 0.0f; angle < 360.0f; angle += 30.0f)
@@ -68,8 +68,9 @@ public class Explosion : Sample
             B2Polygon box = b2MakeBox(1.0f, 0.1f);
             b2CreatePolygonShape(bodyId, ref shapeDef, ref box);
 
-            weldDef.localAnchorA = bodyDef.position;
-            weldDef.bodyIdB = bodyId;
+            weldDef.@base.localFrameA.p = bodyDef.position;
+            weldDef.@base.bodyIdB = bodyId;
+
             B2JointId jointId = b2CreateWeldJoint(m_worldId, ref weldDef);
             m_jointIds.Add(jointId);
         }
@@ -116,7 +117,9 @@ public class Explosion : Sample
             int count = m_jointIds.Count;
             for (int i = 0; i < count; ++i)
             {
-                b2Joint_SetReferenceAngle(m_jointIds[i], m_referenceAngle);
+                B2Transform localFrameA = b2Joint_GetLocalFrameA(m_jointIds[i]);
+                localFrameA.q = b2MakeRot(m_referenceAngle);
+                b2Joint_SetLocalFrameA(m_jointIds[i], localFrameA);
             }
         }
 
@@ -126,9 +129,9 @@ public class Explosion : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         DrawTextLine($"reference angle = {m_referenceAngle:g}");
-        
+
 
         m_draw.DrawCircle(b2Vec2_zero, m_radius + m_falloff, B2HexColor.b2_colorBox2DBlue);
         m_draw.DrawCircle(b2Vec2_zero, m_radius, B2HexColor.b2_colorBox2DYellow);

--- a/src/Box2D.NET.Samples/Samples/Truck.cs
+++ b/src/Box2D.NET.Samples/Samples/Truck.cs
@@ -101,11 +101,11 @@ public class Truck
 
         B2WheelJointDef jointDef = b2DefaultWheelJointDef();
 
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_rearWheelId;
-        jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-        jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-        jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_rearWheelId;
+        jointDef.@base.localFrameA.q = b2MakeRot(0.5f * B2_PI);
+        jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+        jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
         jointDef.motorSpeed = 0.0f;
         jointDef.maxMotorTorque = torque;
         jointDef.enableMotor = true;
@@ -117,11 +117,11 @@ public class Truck
         m_rearAxleId = b2CreateWheelJoint(worldId, ref jointDef);
 
         pivot = b2Body_GetPosition(m_frontWheelId);
-        jointDef.bodyIdA = m_chassisId;
-        jointDef.bodyIdB = m_frontWheelId;
-        jointDef.localAxisA = b2Body_GetLocalVector(jointDef.bodyIdA, axis);
-        jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-        jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+        jointDef.@base.bodyIdA = m_chassisId;
+        jointDef.@base.bodyIdB = m_frontWheelId;
+        jointDef.@base.localFrameA.q = b2MakeRot(0.5f * B2_PI);
+        jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+        jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
         jointDef.motorSpeed = 0.0f;
         jointDef.maxMotorTorque = torque;
         jointDef.enableMotor = true;

--- a/src/Box2D.NET.Shared/Benchmarks.cs
+++ b/src/Box2D.NET.Shared/Benchmarks.cs
@@ -43,7 +43,7 @@ namespace Box2D.NET.Shared
 
             B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.4f);
 
-            B2RevoluteJointDef jd = b2DefaultRevoluteJointDef();
+            B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
             B2BodyDef bodyDef = b2DefaultBodyDef();
 
             for (int k = 0; k < N; ++k)
@@ -70,20 +70,20 @@ namespace Box2D.NET.Shared
 
                     if (i > 0)
                     {
-                        jd.bodyIdA = bodies[index - 1];
-                        jd.bodyIdB = body;
-                        jd.localAnchorA = new B2Vec2(0.0f, -0.5f);
-                        jd.localAnchorB = new B2Vec2(0.0f, 0.5f);
-                        b2CreateRevoluteJoint(worldId, ref jd);
+                        jointDef.@base.bodyIdA = bodies[index - 1];
+                        jointDef.@base.bodyIdB = body;
+                        jointDef.@base.localFrameA.p = new B2Vec2(0.0f, -0.5f);
+                        jointDef.@base.localFrameB.p = new B2Vec2(0.0f, 0.5f);
+                        b2CreateRevoluteJoint(worldId, ref jointDef);
                     }
 
                     if (k > 0)
                     {
-                        jd.bodyIdA = bodies[index - N];
-                        jd.bodyIdB = body;
-                        jd.localAnchorA = new B2Vec2(0.5f, 0.0f);
-                        jd.localAnchorB = new B2Vec2(-0.5f, 0.0f);
-                        b2CreateRevoluteJoint(worldId, ref jd);
+                        jointDef.@base.bodyIdA = bodies[index - N];
+                        jointDef.@base.bodyIdB = body;
+                        jointDef.@base.localFrameA.p = new B2Vec2(0.5f, 0.0f);
+                        jointDef.@base.localFrameB.p = new B2Vec2(-0.5f, 0.0f);
+                        b2CreateRevoluteJoint(worldId, ref jointDef);
                     }
 
                     bodies[index++] = body;
@@ -362,9 +362,9 @@ namespace Box2D.NET.Shared
                 float motorSpeed = 5.0f;
                 float maxMotorTorque = 40000.0f;
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = groundId;
-                jointDef.bodyIdB = spinnerId;
-                jointDef.localAnchorA = bodyDef.position;
+                jointDef.@base.bodyIdA = groundId;
+                jointDef.@base.bodyIdB = spinnerId;
+                jointDef.@base.localFrameA.p = bodyDef.position;
                 jointDef.enableMotor = true;
                 jointDef.motorSpeed = motorSpeed;
                 jointDef.maxMotorTorque = maxMotorTorque;
@@ -499,17 +499,16 @@ namespace Box2D.NET.Shared
 
                 float motorSpeed = 25.0f;
 
-                B2RevoluteJointDef jd = b2DefaultRevoluteJointDef();
-                jd.bodyIdA = groundId;
-                jd.bodyIdB = bodyId;
-                jd.localAnchorA = new B2Vec2(0.0f, 10.0f);
-                jd.localAnchorB = new B2Vec2(0.0f, 0.0f);
-                jd.referenceAngle = 0.0f;
-                jd.motorSpeed = (B2_PI / 180.0f) * motorSpeed;
-                jd.maxMotorTorque = 1e8f;
-                jd.enableMotor = true;
+                B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
+                jointDef.@base.bodyIdA = groundId;
+                jointDef.@base.bodyIdB = bodyId;
+                jointDef.@base.localFrameA.p = new B2Vec2(0.0f, 10.0f);
+                jointDef.@base.localFrameB.p = new B2Vec2(0.0f, 0.0f);
+                jointDef.motorSpeed = (B2_PI / 180.0f) * motorSpeed;
+                jointDef.maxMotorTorque = 1e8f;
+                jointDef.enableMotor = true;
 
-                b2CreateRevoluteJoint(worldId, ref jd);
+                b2CreateRevoluteJoint(worldId, ref jointDef);
             }
 
             int gridCount = BENCHMARK_DEBUG ? 20 : 45;

--- a/src/Box2D.NET.Shared/Determinism.cs
+++ b/src/Box2D.NET.Shared/Determinism.cs
@@ -56,9 +56,9 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = true;
                 jointDef.hertz = 0.5f;
                 jointDef.dampingRatio = 0.5f;
-                jointDef.localAnchorA = new B2Vec2(h, h);
-                jointDef.localAnchorB = new B2Vec2(offset, -h);
-                jointDef.drawSize = 0.1f;
+                jointDef.@base.localFrameA.p = new B2Vec2(h, h);
+                jointDef.@base.localFrameB.p = new B2Vec2(offset, -h);
+                jointDef.@base.drawSize = 0.1f;
 
                 int bodyIndex = 0;
 
@@ -87,8 +87,8 @@ namespace Box2D.NET.Shared
                         }
                         else
                         {
-                            jointDef.bodyIdA = prevBodyId;
-                            jointDef.bodyIdB = bodyId;
+                            jointDef.@base.bodyIdA = prevBodyId;
+                            jointDef.@base.bodyIdB = bodyId;
                             b2CreateRevoluteJoint(worldId, ref jointDef);
                             prevBodyId = b2_nullBodyId;
                         }

--- a/src/Box2D.NET.Shared/Humans.cs
+++ b/src/Box2D.NET.Shared/Humans.cs
@@ -119,10 +119,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.0f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.25f * B2_PI;
                 jointDef.upperAngle = 0.0f;
@@ -131,7 +131,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -162,10 +162,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.4f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.3f * B2_PI;
                 jointDef.upperAngle = 0.1f * B2_PI;
@@ -174,7 +174,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -201,10 +201,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 0.9f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.05f * B2_PI;
                 jointDef.upperAngle = 0.4f * B2_PI;
@@ -213,7 +213,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -257,10 +257,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 0.625f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.5f * B2_PI;
                 jointDef.upperAngle = -0.02f * B2_PI;
@@ -269,7 +269,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -296,10 +296,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 0.9f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.05f * B2_PI;
                 jointDef.upperAngle = 0.4f * B2_PI;
@@ -308,7 +308,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -343,10 +343,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 0.625f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.5f * B2_PI;
                 jointDef.upperAngle = -0.02f * B2_PI;
@@ -355,7 +355,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -382,10 +382,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.35f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.1f * B2_PI;
                 jointDef.upperAngle = 0.8f * B2_PI;
@@ -394,7 +394,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -421,11 +421,11 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.1f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-                jointDef.referenceAngle = 0.25f * B2_PI;
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameA.q = b2MakeRot(0.25f * B2_PI);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.2f * B2_PI;
                 jointDef.upperAngle = 0.3f * B2_PI;
@@ -434,7 +434,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -461,10 +461,10 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.35f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.1f * B2_PI;
                 jointDef.upperAngle = 0.8f * B2_PI;
@@ -473,7 +473,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -500,11 +500,11 @@ namespace Box2D.NET.Shared
 
                 B2Vec2 pivot = b2Add(new B2Vec2(0.0f, 1.1f * s), position);
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-                jointDef.bodyIdA = human.bones[bone.parentIndex].bodyId;
-                jointDef.bodyIdB = bone.bodyId;
-                jointDef.localAnchorA = b2Body_GetLocalPoint(jointDef.bodyIdA, pivot);
-                jointDef.localAnchorB = b2Body_GetLocalPoint(jointDef.bodyIdB, pivot);
-                jointDef.referenceAngle = 0.25f * B2_PI;
+                jointDef.@base.bodyIdA = human.bones[bone.parentIndex].bodyId;
+                jointDef.@base.bodyIdB = bone.bodyId;
+                jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+                jointDef.@base.localFrameA.q = b2MakeRot(0.25f * B2_PI);
+                jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
                 jointDef.enableLimit = enableLimit;
                 jointDef.lowerAngle = -0.2f * B2_PI;
                 jointDef.upperAngle = 0.3f * B2_PI;
@@ -513,7 +513,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.drawSize = drawSize;
+                jointDef.@base.drawSize = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -661,12 +661,12 @@ namespace Box2D.NET.Shared
                     transform.p = b2MulAdd(origin, ratio, b2Sub(transform.p, origin));
                     b2Body_SetTransform(bone.bodyId, transform.p, transform.q);
 
-                    B2Vec2 localAnchorA = b2Joint_GetLocalAnchorA(bone.jointId);
-                    B2Vec2 localAnchorB = b2Joint_GetLocalAnchorB(bone.jointId);
-                    localAnchorA = b2MulSV(ratio, localAnchorA);
-                    localAnchorB = b2MulSV(ratio, localAnchorB);
-                    b2Joint_SetLocalAnchorA(bone.jointId, localAnchorA);
-                    b2Joint_SetLocalAnchorB(bone.jointId, localAnchorB);
+                    B2Transform localFrameA = b2Joint_GetLocalFrameA(bone.jointId);
+                    B2Transform localFrameB = b2Joint_GetLocalFrameB(bone.jointId);
+                    localFrameA.p = b2MulSV(ratio, localFrameA.p);
+                    localFrameB.p = b2MulSV(ratio, localFrameB.p);
+                    b2Joint_SetLocalFrameA(bone.jointId, localFrameA);
+                    b2Joint_SetLocalFrameB(bone.jointId, localFrameB);
 
                     B2JointType type = b2Joint_GetType(bone.jointId);
                     if (type == B2JointType.b2_revoluteJoint)

--- a/src/Box2D.NET/B2Bodies.cs
+++ b/src/Box2D.NET/B2Bodies.cs
@@ -854,7 +854,7 @@ namespace Box2D.NET
             {
                 B2Rot q1 = sim.transform.q;
                 B2Rot q2 = target.q;
-                float deltaAngle = b2RelativeAngle(q2, q1);
+                float deltaAngle = b2RelativeAngle(q1, q2);
                 angularVelocity = invTimeStep * deltaAngle;
             }
 

--- a/src/Box2D.NET/B2BodyState.cs
+++ b/src/Box2D.NET/B2BodyState.cs
@@ -44,7 +44,7 @@ namespace Box2D.NET
         // the solver and must use zero delta rotation for static bodies (c,s) = (1,0)
         public B2Rot deltaRotation; // 8
 
-        public static B2BodyState Create(B2BodyState other)
+        public static B2BodyState Create(B2BodyState other) // todo : @ikpil how to remove
         {
             var state = new B2BodyState();
             state.CopyFrom(other);

--- a/src/Box2D.NET/B2Constants.cs
+++ b/src/Box2D.NET/B2Constants.cs
@@ -51,7 +51,7 @@ namespace Box2D.NET
         public const float B2_JOINT_CONSTRAINT_HERTZ = 60.0f;
 
         // The default joint constraint damping ratio
-        public const float B2_JOINT_CONSTRAINT_DAMPING_RATIO = 2.0f;
+        public const float B2_JOINT_CONSTRAINT_DAMPING_RATIO = 0.0f;
 
 
         // collision

--- a/src/Box2D.NET/B2DistanceJointDef.cs
+++ b/src/Box2D.NET/B2DistanceJointDef.cs
@@ -13,17 +13,8 @@ namespace Box2D.NET
     /// @ingroup distance_joint
     public struct B2DistanceJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// The local anchor point relative to bodyA's origin
-        public B2Vec2 localAnchorA;
-
-        /// The local anchor point relative to bodyB's origin
-        public B2Vec2 localAnchorB;
+        /// Base joint definition
+        public B2JointDef @base;
 
         /// The rest length of this joint. Clamped to a stable minimum value.
         public float length;
@@ -55,12 +46,6 @@ namespace Box2D.NET
 
         /// The desired motor speed, usually in meters per second
         public float motorSpeed;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2DistanceJoints.cs
+++ b/src/Box2D.NET/B2DistanceJoints.cs
@@ -90,8 +90,8 @@ namespace Box2D.NET
             B2Transform transformA = b2GetBodyTransform(world, @base.bodyIdA);
             B2Transform transformB = b2GetBodyTransform(world, @base.bodyIdB);
 
-            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localOriginAnchorA);
-            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localOriginAnchorB);
+            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localFrameA.p);
+            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localFrameB.p);
             B2Vec2 d = b2Sub(pB, pA);
             float length = b2Length(d);
             return length;
@@ -189,8 +189,8 @@ namespace Box2D.NET
             B2Transform transformA = b2GetBodyTransform(world, @base.bodyIdA);
             B2Transform transformB = b2GetBodyTransform(world, @base.bodyIdB);
 
-            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localOriginAnchorA);
-            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localOriginAnchorB);
+            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localFrameA.p);
+            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localFrameB.p);
             B2Vec2 d = b2Sub(pB, pA);
             B2Vec2 axis = b2Normalize(d);
             float force = (joint.impulse + joint.lowerImpulse - joint.upperImpulse + joint.motorImpulse) * world.inv_h;
@@ -251,8 +251,8 @@ namespace Box2D.NET
             joint.indexB = bodyB.setIndex == (int)B2SetType.b2_awakeSet ? localIndexB : B2_NULL_INDEX;
 
             // initial anchors in world space
-            joint.anchorA = b2RotateVector(bodySimA.transform.q, b2Sub(@base.localOriginAnchorA, bodySimA.localCenter));
-            joint.anchorB = b2RotateVector(bodySimB.transform.q, b2Sub(@base.localOriginAnchorB, bodySimB.localCenter));
+            joint.anchorA = b2RotateVector(bodySimA.transform.q, b2Sub(@base.localFrameA.p, bodySimA.localCenter));
+            joint.anchorB = b2RotateVector(bodySimB.transform.q, b2Sub(@base.localFrameB.p, bodySimB.localCenter));
             joint.deltaCenter = b2Sub(bodySimB.center, bodySimA.center);
 
             B2Vec2 rA = joint.anchorA;
@@ -515,8 +515,8 @@ namespace Box2D.NET
 
             ref readonly B2DistanceJoint joint = ref @base.uj.distanceJoint;
 
-            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localOriginAnchorA);
-            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localOriginAnchorB);
+            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localFrameA.p);
+            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localFrameB.p);
 
             B2Vec2 axis = b2Normalize(b2Sub(pB, pA));
 

--- a/src/Box2D.NET/B2JointDef.cs
+++ b/src/Box2D.NET/B2JointDef.cs
@@ -1,0 +1,32 @@
+﻿namespace Box2D.NET
+{
+    public struct B2JointDef
+    {
+        /// User data pointer
+        public object userData;
+
+        /// The first attached body
+        public B2BodyId bodyIdA;
+
+        /// The second attached body
+        public B2BodyId bodyIdB;
+
+        /// The first local joint frame
+        public B2Transform localFrameA;
+
+        /// The second local joint frame
+        public B2Transform localFrameB;
+
+        /// Force threshold for joint events
+        public float forceThreshold;
+
+        /// Torque threshold for joint events
+        public float torqueThreshold;
+
+        /// Debug draw size
+        public float drawSize;
+
+        /// Set this flag to true if the attached bodies should collide
+        public bool collideConnected; 
+    }
+}

--- a/src/Box2D.NET/B2JointEvent.cs
+++ b/src/Box2D.NET/B2JointEvent.cs
@@ -1,0 +1,10 @@
+﻿namespace Box2D.NET
+{
+    /// Joint events report joints that are awake and have a force and/or torque exceeding the threshold
+    /// The observed forces and torques are not returned for efficiency reasons.
+    public struct B2JointEvent
+    {
+        public B2JointId jointId;
+        public object userData;
+    }
+}

--- a/src/Box2D.NET/B2JointEvents.cs
+++ b/src/Box2D.NET/B2JointEvents.cs
@@ -1,0 +1,20 @@
+﻿namespace Box2D.NET
+{
+    /// Joint events are buffered in the Box2D world and are available
+    /// as event arrays after the time step is complete.
+    /// Note: this data becomes invalid if joints are destroyed
+    public readonly struct B2JointEvents
+    {
+        /// Array of events
+        public readonly B2JointEvent[] jointEvents;
+
+        /// Number of events
+        public readonly int count;
+
+        public B2JointEvents(B2JointEvent[] jointEvents, int count)
+        {
+            this.jointEvents = jointEvents;
+            this.count = count;
+        }
+    }
+}

--- a/src/Box2D.NET/B2JointSim.cs
+++ b/src/Box2D.NET/B2JointSim.cs
@@ -15,19 +15,20 @@ namespace Box2D.NET
 
         public B2JointType type;
 
-        // Anchors relative to body origin
-        public B2Vec2 localOriginAnchorA;
-        public B2Vec2 localOriginAnchorB;
+        public B2Transform localFrameA;
+        public B2Transform localFrameB;
 
         public float invMassA, invMassB;
         public float invIA, invIB;
-
 
         public float constraintHertz;
         public float constraintDampingRatio;
 
         public B2Softness constraintSoftness;
 
+        public float forceThreshold;
+        public float torqueThreshold;
+        
         // TODO: @ikpil, check union
         public B2JointUnion uj;
 
@@ -37,8 +38,8 @@ namespace Box2D.NET
             bodyIdA = 0;
             bodyIdB = 0;
             type = B2JointType.b2_distanceJoint;
-            localOriginAnchorA = new B2Vec2();
-            localOriginAnchorB = new B2Vec2();
+            localFrameA = new B2Transform();
+            localFrameB = new B2Transform();
             invMassA = 0.0f;
             invMassB = 0.0f;
             invIA = 0.0f;
@@ -46,6 +47,8 @@ namespace Box2D.NET
             constraintHertz = 0.0f;
             constraintDampingRatio = 0.0f;
             constraintSoftness = new B2Softness();
+            forceThreshold = 0;
+            torqueThreshold = 0;
             uj = new B2JointUnion();
         }
 
@@ -55,8 +58,8 @@ namespace Box2D.NET
             bodyIdA = other.bodyIdA;
             bodyIdB = other.bodyIdB;
             type = other.type;
-            localOriginAnchorA = other.localOriginAnchorA;
-            localOriginAnchorB = other.localOriginAnchorB;
+            localFrameA = other.localFrameA;
+            localFrameB = other.localFrameB;
             invMassA = other.invMassA;
             invMassB = other.invMassB;
             invIA = other.invIA;
@@ -64,6 +67,8 @@ namespace Box2D.NET
             constraintHertz = other.constraintHertz;
             constraintDampingRatio = other.constraintDampingRatio;
             constraintSoftness = other.constraintSoftness;
+            forceThreshold = other.forceThreshold;
+            torqueThreshold = other.torqueThreshold;
             uj = other.uj;
         }
     }

--- a/src/Box2D.NET/B2MotorJoint.cs
+++ b/src/Box2D.NET/B2MotorJoint.cs
@@ -16,10 +16,9 @@ namespace Box2D.NET
 
         public int indexA;
         public int indexB;
-        public B2Vec2 anchorA;
-        public B2Vec2 anchorB;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
-        public float deltaAngle;
         public B2Mat22 linearMass;
         public float angularMass;
     }

--- a/src/Box2D.NET/B2MotorJointDef.cs
+++ b/src/Box2D.NET/B2MotorJointDef.cs
@@ -10,17 +10,8 @@ namespace Box2D.NET
     /// @ingroup motor_joint
     public struct B2MotorJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// Position of bodyB minus the position of bodyA, in bodyA's frame
-        public B2Vec2 linearOffset;
-
-        /// The bodyB angle minus bodyA angle in radians
-        public float angularOffset;
+        /// Base joint definition
+        public B2JointDef @base;
 
         /// The maximum motor force in newtons
         public float maxForce;
@@ -30,12 +21,6 @@ namespace Box2D.NET
 
         /// Position correction factor in the range [0,1]
         public float correctionFactor;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2MouseJoint.cs
+++ b/src/Box2D.NET/B2MouseJoint.cs
@@ -6,7 +6,6 @@ namespace Box2D.NET
 {
     public struct B2MouseJoint
     {
-        public B2Vec2 targetA;
         public float hertz;
         public float dampingRatio;
         public float maxForce;
@@ -16,9 +15,12 @@ namespace Box2D.NET
 
         public B2Softness linearSoftness;
         public B2Softness angularSoftness;
+        public int indexA;
         public int indexB;
-        public B2Vec2 anchorB;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
         public B2Mat22 linearMass;
+        public float axialMass;
     }
 }

--- a/src/Box2D.NET/B2MouseJointDef.cs
+++ b/src/Box2D.NET/B2MouseJointDef.cs
@@ -11,14 +11,8 @@ namespace Box2D.NET
     /// @ingroup mouse_joint
     public struct B2MouseJointDef
     {
-        /// The first attached body. This is assumed to be static.
-        public B2BodyId bodyIdA;
-
-        /// The second attached body.
-        public B2BodyId bodyIdB;
-
-        /// The initial target point in world space
-        public B2Vec2 target;
+        /// Base joint definition
+        public B2JointDef @base;
 
         /// Stiffness in hertz
         public float hertz;
@@ -28,12 +22,6 @@ namespace Box2D.NET
 
         /// Maximum force, typically in newtons
         public float maxForce;
-
-        /// Set this flag to true if the attached bodies should collide.
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2MouseJoints.cs
+++ b/src/Box2D.NET/B2MouseJoints.cs
@@ -7,25 +7,14 @@ using static Box2D.NET.B2Constants;
 using static Box2D.NET.B2MathFunction;
 using static Box2D.NET.B2Solvers;
 using static Box2D.NET.B2Joints;
+using static Box2D.NET.B2Bodies;
 using static Box2D.NET.B2Diagnostics;
 
 namespace Box2D.NET
 {
     public static class B2MouseJoints
     {
-        public static void b2MouseJoint_SetTarget(B2JointId jointId, B2Vec2 target)
-        {
-            B2_ASSERT(b2IsValidVec2(target));
-            B2JointSim @base = b2GetJointSimCheckType(jointId, B2JointType.b2_mouseJoint);
-            @base.uj.mouseJoint.targetA = target;
-        }
-
-        public static B2Vec2 b2MouseJoint_GetTarget(B2JointId jointId)
-        {
-            B2JointSim @base = b2GetJointSimCheckType(jointId, B2JointType.b2_mouseJoint);
-            return @base.uj.mouseJoint.targetA;
-        }
-
+        /// Set the mouse joint spring stiffness in Hertz
         public static void b2MouseJoint_SetSpringHertz(B2JointId jointId, float hertz)
         {
             B2_ASSERT(b2IsValidFloat(hertz) && hertz >= 0.0f);
@@ -33,6 +22,7 @@ namespace Box2D.NET
             @base.uj.mouseJoint.hertz = hertz;
         }
 
+        /// Get the mouse joint spring stiffness in Hertz
         public static float b2MouseJoint_GetSpringHertz(B2JointId jointId)
         {
             B2JointSim @base = b2GetJointSimCheckType(jointId, B2JointType.b2_mouseJoint);
@@ -81,24 +71,47 @@ namespace Box2D.NET
             B2_ASSERT(@base.type == B2JointType.b2_mouseJoint);
 
             // chase body id to the solver set where the body lives
+            int idA = @base.bodyIdA;
             int idB = @base.bodyIdB;
 
             B2World world = context.world;
 
+            B2Body bodyA = b2Array_Get(ref world.bodies, idA);
             B2Body bodyB = b2Array_Get(ref world.bodies, idB);
 
-            B2_ASSERT(bodyB.setIndex == (int)B2SetType.b2_awakeSet);
+            B2_ASSERT(bodyA.setIndex == (int)B2SetType.b2_awakeSet || bodyB.setIndex == (int)B2SetType.b2_awakeSet);
+            B2SolverSet setA = b2Array_Get(ref world.solverSets, bodyA.setIndex);
             B2SolverSet setB = b2Array_Get(ref world.solverSets, bodyB.setIndex);
 
+            int localIndexA = bodyA.localIndex;
             int localIndexB = bodyB.localIndex;
+
+            B2BodySim bodySimA = b2Array_Get(ref setA.bodySims, localIndexA);
             B2BodySim bodySimB = b2Array_Get(ref setB.bodySims, localIndexB);
 
-            @base.invMassB = bodySimB.invMass;
-            @base.invIB = bodySimB.invInertia;
+            float mA = bodySimA.invMass;
+            float iA = bodySimA.invInertia;
+            float mB = bodySimB.invMass;
+            float iB = bodySimB.invInertia;
+
+            @base.invMassA = mA;
+            @base.invMassB = mB;
+            @base.invIA = iA;
+            @base.invIB = iB;
 
             ref B2MouseJoint joint = ref @base.uj.mouseJoint;
+
+            joint.indexA = bodyA.setIndex == (int)B2SetType.b2_awakeSet ? localIndexA : B2_NULL_INDEX;
             joint.indexB = bodyB.setIndex == (int)B2SetType.b2_awakeSet ? localIndexB : B2_NULL_INDEX;
-            joint.anchorB = b2RotateVector(bodySimB.transform.q, b2Sub(@base.localOriginAnchorB, bodySimB.localCenter));
+
+            // Compute joint anchor frames with world space rotation, relative to center of mass
+            joint.frameA.q = b2MulRot(bodySimA.transform.q, @base.localFrameA.q);
+            joint.frameA.p = b2RotateVector(bodySimA.transform.q, b2Sub(@base.localFrameA.p, bodySimA.localCenter));
+            joint.frameB.q = b2MulRot(bodySimB.transform.q, @base.localFrameB.q);
+            joint.frameB.p = b2RotateVector(bodySimB.transform.q, b2Sub(@base.localFrameB.p, bodySimB.localCenter));
+
+            // Compute the initial center delta. Incremental position updates are relative to this.
+            joint.deltaCenter = b2Sub(bodySimB.center, bodySimA.center);
 
             joint.linearSoftness = b2MakeSoft(joint.hertz, joint.dampingRatio, context.h);
 
@@ -106,21 +119,21 @@ namespace Box2D.NET
             float angularDampingRatio = 0.1f;
             joint.angularSoftness = b2MakeSoft(angularHertz, angularDampingRatio, context.h);
 
-            B2Vec2 rB = joint.anchorB;
-            float mB = bodySimB.invMass;
-            float iB = bodySimB.invInertia;
+            B2Vec2 rA = joint.frameA.p;
+            B2Vec2 rB = joint.frameB.p;
 
             // K = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
             //   = [1/m1+1/m2     0    ] + invI1 * [r1.y*r1.y -r1.x*r1.y] + invI2 * [r1.y*r1.y -r1.x*r1.y]
             //     [    0     1/m1+1/m2]           [-r1.x*r1.y r1.x*r1.x]           [-r1.x*r1.y r1.x*r1.x]
             B2Mat22 K;
-            K.cx.X = mB + iB * rB.Y * rB.Y;
-            K.cx.Y = -iB * rB.X * rB.Y;
+            K.cx.X = mA + mB + rA.Y * rA.Y * iA + rB.Y * rB.Y * iB;
+            K.cx.Y = -rA.Y * rA.X * iA - rB.Y * rB.X * iB;
             K.cy.X = K.cx.Y;
-            K.cy.Y = mB + iB * rB.X * rB.X;
-
+            K.cy.Y = mA + mB + rA.X * rA.X * iA + rB.X * rB.X * iB;
             joint.linearMass = b2GetInverse22(K);
-            joint.deltaCenter = b2Sub(bodySimB.center, joint.targetA);
+
+            float ka = iA + iB;
+            joint.axialMass = ka > 0.0f ? 1.0f / ka : 0.0f;
 
             if (context.enableWarmStarting == false)
             {
@@ -133,33 +146,47 @@ namespace Box2D.NET
         {
             B2_ASSERT(@base.type == B2JointType.b2_mouseJoint);
 
+            float mA = @base.invMassA;
             float mB = @base.invMassB;
+            float iA = @base.invIA;
             float iB = @base.invIB;
 
-            ref readonly B2MouseJoint joint = ref @base.uj.mouseJoint;
+            ref B2MouseJoint joint = ref @base.uj.mouseJoint;
 
-            B2BodyState stateB = context.states[joint.indexB];
-            B2Vec2 vB = stateB.linearVelocity;
-            float wB = stateB.angularVelocity;
+            // dummy state for static bodies
+            B2BodyState dummyState = B2BodyState.Create(b2_identityBodyState);
 
-            B2Rot dqB = stateB.deltaRotation;
-            B2Vec2 rB = b2RotateVector(dqB, joint.anchorB);
+            B2BodyState stateA = joint.indexA == B2_NULL_INDEX ? dummyState : context.states[joint.indexA];
+            B2BodyState stateB = joint.indexB == B2_NULL_INDEX ? dummyState : context.states[joint.indexB];
 
-            vB = b2MulAdd(vB, mB, joint.linearImpulse);
-            wB += iB * (b2Cross(rB, joint.linearImpulse) + joint.angularImpulse);
+            B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.frameA.p);
+            B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.frameB.p);
 
-            stateB.linearVelocity = vB;
-            stateB.angularVelocity = wB;
+            stateA.linearVelocity = b2MulSub(stateA.linearVelocity, mA, joint.linearImpulse);
+            stateA.angularVelocity -= iA * (b2Cross(rA, joint.linearImpulse) + joint.angularImpulse);
+            stateB.linearVelocity = b2MulAdd(stateB.linearVelocity, mB, joint.linearImpulse);
+            stateB.angularVelocity += iB * (b2Cross(rB, joint.linearImpulse) + joint.angularImpulse);
+            ;
         }
 
         public static void b2SolveMouseJoint(B2JointSim @base, B2StepContext context)
         {
+            B2_ASSERT(@base.type == B2JointType.b2_mouseJoint);
+
+            float mA = @base.invMassA;
             float mB = @base.invMassB;
+            float iA = @base.invIA;
             float iB = @base.invIB;
 
-            ref B2MouseJoint joint = ref @base.uj.mouseJoint;
-            B2BodyState stateB = context.states[joint.indexB];
+            // dummy state for static bodies
+            B2BodyState dummyState = B2BodyState.Create(b2_identityBodyState);
 
+            ref B2MouseJoint joint = ref @base.uj.mouseJoint;
+            B2BodyState stateA = joint.indexA == B2_NULL_INDEX ? dummyState : context.states[joint.indexA];
+            B2BodyState stateB = joint.indexB == B2_NULL_INDEX ? dummyState : context.states[joint.indexB];
+
+            B2Vec2 vA = stateA.linearVelocity;
+            float wA = stateA.angularVelocity;
             B2Vec2 vB = stateB.linearVelocity;
             float wB = stateB.angularVelocity;
 
@@ -168,22 +195,26 @@ namespace Box2D.NET
                 float massScale = joint.angularSoftness.massScale;
                 float impulseScale = joint.angularSoftness.impulseScale;
 
-                float impulse = iB > 0.0f ? -wB / iB : 0.0f;
-                impulse = massScale * impulse - impulseScale * joint.angularImpulse;
+                float Cdot = wB - wA;
+                float impulse = -massScale * joint.axialMass * Cdot - impulseScale * joint.angularImpulse;
                 joint.angularImpulse += impulse;
 
+                wA -= iA * impulse;
                 wB += iB * impulse;
             }
 
             float maxImpulse = joint.maxForce * context.h;
 
             {
-                B2Rot dqB = stateB.deltaRotation;
-                B2Vec2 rB = b2RotateVector(dqB, joint.anchorB);
-                B2Vec2 Cdot = b2Add(vB, b2CrossSV(wB, rB));
+                B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.frameA.p);
+                B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.frameB.p);
 
-                B2Vec2 separation = b2Add(b2Add(stateB.deltaPosition, rB), joint.deltaCenter);
-                B2Vec2 bias = b2MulSV(joint.linearSoftness.biasRate, separation);
+                B2Vec2 Cdot = b2Sub(b2Add(vB, b2CrossSV(wB, rB)), b2Add(vA, b2CrossSV(wA, rA)));
+
+                B2Vec2 dcA = stateA.deltaPosition;
+                B2Vec2 dcB = stateB.deltaPosition;
+                B2Vec2 C = b2Add(b2Add(b2Sub(dcB, dcA), b2Sub(rB, rA)), joint.deltaCenter);
+                B2Vec2 bias = b2MulSV(joint.linearSoftness.biasRate, C);
 
                 float massScale = joint.linearSoftness.massScale;
                 float impulseScale = joint.linearSoftness.impulseScale;
@@ -198,19 +229,23 @@ namespace Box2D.NET
                 joint.linearImpulse.X += impulse.X;
                 joint.linearImpulse.Y += impulse.Y;
 
-                float mag = b2Length(joint.linearImpulse);
-                if (mag > maxImpulse)
+                float lengthSquared = b2LengthSquared(joint.linearImpulse);
+                if (lengthSquared > maxImpulse * maxImpulse)
                 {
                     joint.linearImpulse = b2MulSV(maxImpulse, b2Normalize(joint.linearImpulse));
                 }
 
-                impulse.X = joint.linearImpulse.X - oldImpulse.X;
                 impulse.Y = joint.linearImpulse.Y - oldImpulse.Y;
+                impulse.X = joint.linearImpulse.X - oldImpulse.X;
 
+                vA = b2MulSub(vA, mA, impulse);
+                wA -= iA * b2Cross(rA, impulse);
                 vB = b2MulAdd(vB, mB, impulse);
                 wB += iB * b2Cross(rB, impulse);
             }
 
+            stateA.linearVelocity = vA;
+            stateA.angularVelocity = wA;
             stateB.linearVelocity = vB;
             stateB.angularVelocity = wB;
         }

--- a/src/Box2D.NET/B2PrismaticJoint.cs
+++ b/src/Box2D.NET/B2PrismaticJoint.cs
@@ -6,7 +6,6 @@ namespace Box2D.NET
 {
     public struct B2PrismaticJoint
     {
-        public B2Vec2 localAxisA;
         public B2Vec2 impulse;
         public float springImpulse;
         public float motorImpulse;
@@ -17,17 +16,14 @@ namespace Box2D.NET
         public float targetTranslation;
         public float maxMotorForce;
         public float motorSpeed;
-        public float referenceAngle;
         public float lowerTranslation;
         public float upperTranslation;
 
         public int indexA;
         public int indexB;
-        public B2Vec2 anchorA;
-        public B2Vec2 anchorB;
-        public B2Vec2 axisA;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
-        public float deltaAngle;
         public float axialMass;
         public B2Softness springSoftness;
 

--- a/src/Box2D.NET/B2PrismaticJointDef.cs
+++ b/src/Box2D.NET/B2PrismaticJointDef.cs
@@ -13,23 +13,8 @@ namespace Box2D.NET
     /// @ingroup prismatic_joint
     public struct B2PrismaticJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// The local anchor point relative to bodyA's origin
-        public B2Vec2 localAnchorA;
-
-        /// The local anchor point relative to bodyB's origin
-        public B2Vec2 localAnchorB;
-
-        /// The local translation unit axis in bodyA
-        public B2Vec2 localAxisA;
-
-        /// The constrained angle between the bodies: bodyB_angle - bodyA_angle
-        public float referenceAngle;
+        /// Base joint definition
+        public B2JointDef @base;
         
         /// The target translation for the joint in meters. The spring-damper will drive
         /// to this translation.
@@ -61,12 +46,6 @@ namespace Box2D.NET
 
         /// The desired motor speed, typically in meters per second
         public float motorSpeed;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2Profile.cs
+++ b/src/Box2D.NET/B2Profile.cs
@@ -25,6 +25,7 @@ namespace Box2D.NET
         public float storeImpulses;
         public float splitIslands;
         public float transforms;
+        public float jointEvents;
         public float hitEvents;
         public float refit;
         public float bullets;

--- a/src/Box2D.NET/B2RevoluteJoint.cs
+++ b/src/Box2D.NET/B2RevoluteJoint.cs
@@ -16,16 +16,14 @@ namespace Box2D.NET
         public float targetAngle;
         public float maxMotorTorque;
         public float motorSpeed;
-        public float referenceAngle;
         public float lowerAngle;
         public float upperAngle;
 
         public int indexA;
         public int indexB;
-        public B2Vec2 anchorA;
-        public B2Vec2 anchorB;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
-        public float deltaAngle;
         public float axialMass;
         public B2Softness springSoftness;
 

--- a/src/Box2D.NET/B2RevoluteJointDef.cs
+++ b/src/Box2D.NET/B2RevoluteJointDef.cs
@@ -18,21 +18,8 @@ namespace Box2D.NET
     /// @ingroup revolute_joint
     public struct B2RevoluteJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// The local anchor point relative to bodyA's origin
-        public B2Vec2 localAnchorA;
-
-        /// The local anchor point relative to bodyB's origin
-        public B2Vec2 localAnchorB;
-
-        /// The bodyB angle minus bodyA angle in the reference state (radians).
-        /// This defines the zero angle for the joint limit.
-        public float referenceAngle;
+        /// Base joint definition
+        public B2JointDef @base;
         
         /// The target angle for the joint in radians. The spring-damper will drive
         /// to this angle.
@@ -64,15 +51,6 @@ namespace Box2D.NET
 
         /// The desired motor speed in radians per second
         public float motorSpeed;
-
-        /// Scale the debug draw
-        public float drawSize;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2TaskContext.cs
+++ b/src/Box2D.NET/B2TaskContext.cs
@@ -7,8 +7,11 @@ namespace Box2D.NET
     // Per thread task storage
     public class B2TaskContext
     {
-        // These bits align with the b2ConstraintGraph::contactBlocks and signal a change in contact status
+        // These bits align with the contact id capacity and signal a change in contact status
         public B2BitSet contactStateBitSet;
+
+        // These bits align with the joint id capacity and signal a change in contact status
+        public B2BitSet jointStateBitSet;
 
         // Used to track bodies with shapes that have enlarged AABBs. This avoids having a bit array
         // that is very large when there are many static shapes.

--- a/src/Box2D.NET/B2TracyCZone.cs
+++ b/src/Box2D.NET/B2TracyCZone.cs
@@ -34,6 +34,7 @@ namespace Box2D.NET
         prepare_stages,
         solve_constraints,
         update_transforms,
+        joint_events,
         hit_events,
         refit_bvh,
         bullets,

--- a/src/Box2D.NET/B2WeldJoint.cs
+++ b/src/Box2D.NET/B2WeldJoint.cs
@@ -6,7 +6,6 @@ namespace Box2D.NET
 {
     public struct B2WeldJoint
     {
-        public float referenceAngle;
         public float linearHertz;
         public float linearDampingRatio;
         public float angularHertz;
@@ -19,10 +18,9 @@ namespace Box2D.NET
 
         public int indexA;
         public int indexB;
-        public B2Vec2 anchorA;
-        public B2Vec2 anchorB;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
-        public float deltaAngle;
         public float axialMass;
     }
 }

--- a/src/Box2D.NET/B2WeldJointDef.cs
+++ b/src/Box2D.NET/B2WeldJointDef.cs
@@ -12,22 +12,9 @@ namespace Box2D.NET
     /// @ingroup weld_joint
     public struct B2WeldJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// The local anchor point relative to bodyA's origin
-        public B2Vec2 localAnchorA;
-
-        /// The local anchor point relative to bodyB's origin
-        public B2Vec2 localAnchorB;
-
-        /// The bodyB angle minus bodyA angle in the reference state (radians)
-        /// todo maybe make this a b2Rot
-        public float referenceAngle;
-
+        /// Base joint definition
+        public B2JointDef @base;
+            
         /// Linear stiffness expressed as Hertz (cycles per second). Use zero for maximum stiffness.
         public float linearHertz;
 
@@ -39,12 +26,6 @@ namespace Box2D.NET
 
         /// Linear damping ratio, non-dimensional. Use 1 for critical damping.
         public float angularDampingRatio;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2WheelJoint.cs
+++ b/src/Box2D.NET/B2WheelJoint.cs
@@ -6,7 +6,6 @@ namespace Box2D.NET
 {
     public struct B2WheelJoint
     {
-        public B2Vec2 localAxisA;
         public float perpImpulse;
         public float motorImpulse;
         public float springImpulse;
@@ -21,9 +20,8 @@ namespace Box2D.NET
 
         public int indexA;
         public int indexB;
-        public B2Vec2 anchorA;
-        public B2Vec2 anchorB;
-        public B2Vec2 axisA;
+        public B2Transform frameA;
+        public B2Transform frameB;
         public B2Vec2 deltaCenter;
         public float perpMass;
         public float motorMass;

--- a/src/Box2D.NET/B2WheelJointDef.cs
+++ b/src/Box2D.NET/B2WheelJointDef.cs
@@ -13,20 +13,8 @@ namespace Box2D.NET
     /// @ingroup wheel_joint
     public struct B2WheelJointDef
     {
-        /// The first attached body
-        public B2BodyId bodyIdA;
-
-        /// The second attached body
-        public B2BodyId bodyIdB;
-
-        /// The local anchor point relative to bodyA's origin
-        public B2Vec2 localAnchorA;
-
-        /// The local anchor point relative to bodyB's origin
-        public B2Vec2 localAnchorB;
-
-        /// The local translation unit axis in bodyA
-        public B2Vec2 localAxisA;
+        /// Base joint definition
+        public B2JointDef @base;
 
         /// Enable a linear spring along the local axis
         public bool enableSpring;
@@ -54,12 +42,6 @@ namespace Box2D.NET
 
         /// The desired motor speed in radians per second
         public float motorSpeed;
-
-        /// Set this flag to true if the attached bodies should collide
-        public bool collideConnected;
-
-        /// User data pointer
-        public object userData;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/src/Box2D.NET/B2WheelJoints.cs
+++ b/src/Box2D.NET/B2WheelJoints.cs
@@ -148,11 +148,14 @@ namespace Box2D.NET
 
         public static B2Vec2 b2GetWheelJointForce(B2World world, B2JointSim @base)
         {
-            ref readonly B2WheelJoint joint = ref @base.uj.wheelJoint;
+            int idA = @base.bodyIdA;
+            B2Transform transformA = b2GetBodyTransform(world, idA);
 
-            // This is a frame behind
-            B2Vec2 axisA = joint.axisA;
+            B2Vec2 localAxisA = b2RotateVector(@base.localFrameA.q, new B2Vec2(1.0f, 0.0f));
+            B2Vec2 axisA = b2RotateVector(transformA.q, localAxisA);
             B2Vec2 perpA = b2LeftPerp(axisA);
+
+            ref readonly B2WheelJoint joint = ref @base.uj.wheelJoint;
 
             float perpForce = world.inv_h * joint.perpImpulse;
             float axialForce = world.inv_h * (joint.springImpulse + joint.lowerImpulse - joint.upperImpulse);
@@ -220,19 +223,20 @@ namespace Box2D.NET
             joint.indexA = bodyA.setIndex == (int)B2SetType.b2_awakeSet ? localIndexA : B2_NULL_INDEX;
             joint.indexB = bodyB.setIndex == (int)B2SetType.b2_awakeSet ? localIndexB : B2_NULL_INDEX;
 
-            B2Rot qA = bodySimA.transform.q;
-            B2Rot qB = bodySimB.transform.q;
+            // Compute joint anchor frames with world space rotation, relative to center of mass
+            joint.frameA.q = b2MulRot(bodySimA.transform.q, @base.localFrameA.q);
+            joint.frameA.p = b2RotateVector(bodySimA.transform.q, b2Sub(@base.localFrameA.p, bodySimA.localCenter));
+            joint.frameB.q = b2MulRot(bodySimB.transform.q, @base.localFrameB.q);
+            joint.frameB.p = b2RotateVector(bodySimB.transform.q, b2Sub(@base.localFrameB.p, bodySimB.localCenter));
 
-            joint.anchorA = b2RotateVector(qA, b2Sub(@base.localOriginAnchorA, bodySimA.localCenter));
-            joint.anchorB = b2RotateVector(qB, b2Sub(@base.localOriginAnchorB, bodySimB.localCenter));
-            joint.axisA = b2RotateVector(qA, joint.localAxisA);
+            // Compute the initial center delta. Incremental position updates are relative to this.
             joint.deltaCenter = b2Sub(bodySimB.center, bodySimA.center);
 
-            B2Vec2 rA = joint.anchorA;
-            B2Vec2 rB = joint.anchorB;
+            B2Vec2 rA = joint.frameA.p;
+            B2Vec2 rB = joint.frameB.p;
 
             B2Vec2 d = b2Add(joint.deltaCenter, b2Sub(rB, rA));
-            B2Vec2 axisA = joint.axisA;
+            B2Vec2 axisA = b2RotateVector(joint.frameA.q, new B2Vec2(1.0f, 0.0f));
             B2Vec2 perpA = b2LeftPerp(axisA);
 
             // perpendicular constraint (keep wheel on line)
@@ -281,11 +285,12 @@ namespace Box2D.NET
             B2BodyState stateA = joint.indexA == B2_NULL_INDEX ? dummyState : context.states[joint.indexA];
             B2BodyState stateB = joint.indexB == B2_NULL_INDEX ? dummyState : context.states[joint.indexB];
 
-            B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.anchorA);
-            B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.anchorB);
+            B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.frameA.p);
+            B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.frameB.p);
 
             B2Vec2 d = b2Add(b2Add(b2Sub(stateB.deltaPosition, stateA.deltaPosition), joint.deltaCenter), b2Sub(rB, rA));
-            B2Vec2 axisA = b2RotateVector(stateA.deltaRotation, joint.axisA);
+            B2Vec2 axisA = b2RotateVector(joint.frameA.q, new B2Vec2(1.0f, 0.0f));
+            axisA = b2RotateVector(stateA.deltaRotation, axisA);
             B2Vec2 perpA = b2LeftPerp(axisA);
 
             float a1 = b2Cross(b2Add(d, rA), axisA);
@@ -330,11 +335,12 @@ namespace Box2D.NET
             bool fixedRotation = (iA + iB == 0.0f);
 
             // current anchors
-            B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.anchorA);
-            B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.anchorB);
+            B2Vec2 rA = b2RotateVector(stateA.deltaRotation, joint.frameA.p);
+            B2Vec2 rB = b2RotateVector(stateB.deltaRotation, joint.frameB.p);
 
             B2Vec2 d = b2Add(b2Add(b2Sub(stateB.deltaPosition, stateA.deltaPosition), joint.deltaCenter), b2Sub(rB, rA));
-            B2Vec2 axisA = b2RotateVector(stateA.deltaRotation, joint.axisA);
+            B2Vec2 axisA = b2RotateVector(joint.frameA.q, new B2Vec2(1.0f, 0.0f));
+            axisA = b2RotateVector(stateA.deltaRotation, axisA);
             float translation = b2Dot(axisA, d);
 
             float a1 = b2Cross(b2Add(d, rA), axisA);
@@ -522,9 +528,9 @@ namespace Box2D.NET
 
             ref readonly B2WheelJoint joint = ref @base.uj.wheelJoint;
 
-            B2Vec2 pA = b2TransformPoint(ref transformA, @base.localOriginAnchorA);
-            B2Vec2 pB = b2TransformPoint(ref transformB, @base.localOriginAnchorB);
-            B2Vec2 axis = b2RotateVector(transformA.q, joint.localAxisA);
+            B2Transform frameA = b2MulTransforms(transformA, @base.localFrameA);
+            B2Transform frameB = b2MulTransforms(transformB, @base.localFrameB);
+            B2Vec2 axisA = b2RotateVector(frameA.q, new B2Vec2(1.0f, 0.0f));
 
             B2HexColor c1 = B2HexColor.b2_colorGray;
             B2HexColor c2 = B2HexColor.b2_colorGreen;
@@ -532,24 +538,24 @@ namespace Box2D.NET
             B2HexColor c4 = B2HexColor.b2_colorDimGray;
             B2HexColor c5 = B2HexColor.b2_colorBlue;
 
-            draw.DrawSegmentFcn(pA, pB, c5, draw.context);
+            draw.DrawSegmentFcn(frameA.p, frameB.p, c5, draw.context);
 
             if (joint.enableLimit)
             {
-                B2Vec2 lower = b2MulAdd(pA, joint.lowerTranslation, axis);
-                B2Vec2 upper = b2MulAdd(pA, joint.upperTranslation, axis);
-                B2Vec2 perp = b2LeftPerp(axis);
+                B2Vec2 lower = b2MulAdd(frameA.p, joint.lowerTranslation, axisA);
+                B2Vec2 upper = b2MulAdd(frameA.p, joint.upperTranslation, axisA);
+                B2Vec2 perp = b2LeftPerp(axisA);
                 draw.DrawSegmentFcn(lower, upper, c1, draw.context);
                 draw.DrawSegmentFcn(b2MulSub(lower, 0.1f, perp), b2MulAdd(lower, 0.1f, perp), c2, draw.context);
                 draw.DrawSegmentFcn(b2MulSub(upper, 0.1f, perp), b2MulAdd(upper, 0.1f, perp), c3, draw.context);
             }
             else
             {
-                draw.DrawSegmentFcn(b2MulSub(pA, 1.0f, axis), b2MulAdd(pA, 1.0f, axis), c1, draw.context);
+                draw.DrawSegmentFcn(b2MulSub(frameA.p, 1.0f, axisA), b2MulAdd(frameA.p, 1.0f, axisA), c1, draw.context);
             }
 
-            draw.DrawPointFcn(pA, 5.0f, c1, draw.context);
-            draw.DrawPointFcn(pB, 5.0f, c4, draw.context);
+            draw.DrawPointFcn(frameA.p, 5.0f, c1, draw.context);
+            draw.DrawPointFcn(frameB.p, 5.0f, c4, draw.context);
         }
     }
 }

--- a/src/Box2D.NET/B2World.cs
+++ b/src/Box2D.NET/B2World.cs
@@ -70,6 +70,7 @@ namespace Box2D.NET
         public B2Array<B2BodyMoveEvent> bodyMoveEvents;
         public B2Array<B2SensorBeginTouchEvent> sensorBeginEvents;
         public B2Array<B2ContactBeginTouchEvent> contactBeginEvents;
+        public B2Array<B2JointEvent> jointEvents;
 
         // End events are double buffered so that the user doesn't need to flush events
         public B2Array<B2SensorEndTouchEvent>[] sensorEndEvents = new B2Array<B2SensorEndTouchEvent>[2];
@@ -183,6 +184,7 @@ namespace Box2D.NET
             bodyMoveEvents = new B2Array<B2BodyMoveEvent>();
             sensorBeginEvents = new B2Array<B2SensorBeginTouchEvent>();
             contactBeginEvents = new B2Array<B2ContactBeginTouchEvent>();
+            jointEvents = new B2Array<B2JointEvent>();
 
             sensorEndEvents[0] = new B2Array<B2SensorEndTouchEvent>();
             sensorEndEvents[1] = new B2Array<B2SensorEndTouchEvent>();

--- a/src/Box2D.NET/B2Worlds.cs
+++ b/src/Box2D.NET/B2Worlds.cs
@@ -197,6 +197,7 @@ namespace Box2D.NET
             world.contactEndEvents[0] = b2Array_Create<B2ContactEndTouchEvent>(4);
             world.contactEndEvents[1] = b2Array_Create<B2ContactEndTouchEvent>(4);
             world.contactHitEvents = b2Array_Create<B2ContactHitEvent>(4);
+            world.jointEvents = b2Array_Create<B2JointEvent>(4);
             world.endEventArrayIndex = 0;
 
             world.stepIndex = 0;
@@ -264,6 +265,7 @@ namespace Box2D.NET
             for (int i = 0; i < world.workerCount; ++i)
             {
                 world.taskContexts.data[i].contactStateBitSet = b2CreateBitSet(1024);
+                world.taskContexts.data[i].jointStateBitSet = b2CreateBitSet(1024);
                 world.taskContexts.data[i].enlargedSimBitSet = b2CreateBitSet(256);
                 world.taskContexts.data[i].awakeIslandBitSet = b2CreateBitSet(256);
 
@@ -291,6 +293,7 @@ namespace Box2D.NET
             for (int i = 0; i < world.workerCount; ++i)
             {
                 b2DestroyBitSet(ref world.taskContexts.data[i].contactStateBitSet);
+                b2DestroyBitSet(ref world.taskContexts.data[i].jointStateBitSet);
                 b2DestroyBitSet(ref world.taskContexts.data[i].enlargedSimBitSet);
                 b2DestroyBitSet(ref world.taskContexts.data[i].awakeIslandBitSet);
 
@@ -308,6 +311,7 @@ namespace Box2D.NET
             b2Array_Destroy(ref world.contactEndEvents[0]);
             b2Array_Destroy(ref world.contactEndEvents[1]);
             b2Array_Destroy(ref world.contactHitEvents);
+            b2Array_Destroy(ref world.jointEvents);
 
             int chainCapacity = world.chainShapes.count;
             for (int i = 0; i < chainCapacity; ++i)
@@ -730,6 +734,7 @@ namespace Box2D.NET
             b2Array_Clear(ref world.sensorBeginEvents);
             b2Array_Clear(ref world.contactBeginEvents);
             b2Array_Clear(ref world.contactHitEvents);
+            b2Array_Clear(ref world.jointEvents);
 
             // world.profile = ( b2Profile ){ 0 };
             world.profile = new B2Profile();
@@ -1513,6 +1518,7 @@ namespace Box2D.NET
             }
         }
 
+        /// Get the body events for the current time step. The event data is transient. Do not store a reference to this data.
         public static B2BodyEvents b2World_GetBodyEvents(B2WorldId worldId)
         {
             B2World world = b2GetWorldFromId(worldId);
@@ -1527,6 +1533,7 @@ namespace Box2D.NET
             return events;
         }
 
+        /// Get sensor events for the current time step. The event data is transient. Do not store a reference to this data.
         public static B2SensorEvents b2World_GetSensorEvents(B2WorldId worldId)
         {
             B2World world = b2GetWorldFromId(worldId);
@@ -1552,6 +1559,7 @@ namespace Box2D.NET
             return events;
         }
 
+        /// Get contact events for this current time step. The event data is transient. Do not store a reference to this data.
         public static B2ContactEvents b2World_GetContactEvents(B2WorldId worldId)
         {
             B2World world = b2GetWorldFromId(worldId);
@@ -1578,6 +1586,21 @@ namespace Box2D.NET
                 hitCount = hitCount,
             };
 
+            return events;
+        }
+
+        /// Get the joint events for the current time step. The event data is transient. Do not store a reference to this data.
+        public static B2JointEvents b2World_GetJointEvents(B2WorldId worldId)
+        {
+            B2World world = b2GetWorldFromId(worldId);
+            B2_ASSERT(world.locked == false);
+            if (world.locked)
+            {
+                return new B2JointEvents();
+            }
+
+            int count = world.jointEvents.count;
+            B2JointEvents events = new B2JointEvents(world.jointEvents.data, count);
             return events;
         }
 

--- a/src/Box2D.NET/b2FilterJointDef.cs
+++ b/src/Box2D.NET/b2FilterJointDef.cs
@@ -9,14 +9,8 @@ namespace Box2D.NET
     /// @ingroup filter_joint
     public struct b2FilterJointDef
     {
-        /// The first attached body.
-        public B2BodyId bodyIdA;
-
-        /// The second attached body.
-        public B2BodyId bodyIdB;
-
-        /// User data pointer
-        public object userData;
+        /// Base joint definition
+        public B2JointDef @base;
 
         /// Used internally to detect a valid definition. DO NOT SET.
         public int internalValue;

--- a/test/Box2D.NET.Test/B2DeterminismTest.cs
+++ b/test/Box2D.NET.Test/B2DeterminismTest.cs
@@ -131,8 +131,8 @@ public class b2TaskTester : IDisposable
 
 public class B2DeterminismTest
 {
-    private const int EXPECTED_SLEEP_STEP = 288;
-    private const uint EXPECTED_HASH = 0x35467e1e;
+    private const int EXPECTED_SLEEP_STEP = 342;
+    private const uint EXPECTED_HASH = 0xd8d6b53a;
 
     private const int e_maxTasks = 128;
 

--- a/test/Box2D.NET.Test/B2MathTest.cs
+++ b/test/Box2D.NET.Test/B2MathTest.cs
@@ -162,5 +162,19 @@ public class B2MathTest
             Assert.That(alpha * 0.5f * B2_PI - angle, Is.LessThan(5.0f * B2_PI / 180.0f));
             //printf("angle = [%g %g %g]\n", alpha, alpha * 0.5f * B2_PI, angle);
         }
+
+        // Test relative angle
+        float baseAngle = 0.75f * B2_PI;
+        q1 = b2MakeRot(baseAngle);
+        for (float t = -10.0f; t < 10.0f; t += 0.01f)
+        {
+            float angle = B2_PI * t;
+            q2 = b2MakeRot(angle);
+
+            float relativeAngle = b2RelativeAngle(q1, q2);
+            float unwoundAngle = b2UnwindAngle(angle - baseAngle);
+            float tolerance = 0.1f * B2_PI / 180.0f;
+            Assert.That(relativeAngle - unwoundAngle, Is.LessThan(tolerance));
+        }
     }
 }

--- a/test/Box2D.NET.Test/B2RotTest.cs
+++ b/test/Box2D.NET.Test/B2RotTest.cs
@@ -113,7 +113,7 @@ public class B2RotTest
     {
         var rot1 = b2MakeRot(0.0f);
         var rot2 = b2MakeRot(B2_PI / 2);
-        Assert.That(b2RelativeAngle(rot2, rot1), Is.EqualTo(B2_PI / 2).Within(FLT_EPSILON), "Relative angle between 0 and 90 degrees should be 90 degrees");
+        Assert.That(b2RelativeAngle(rot1, rot2), Is.EqualTo(B2_PI / 2).Within(FLT_EPSILON), "Relative angle between 0 and 90 degrees should be 90 degrees");
     }
 
     [Test]


### PR DESCRIPTION
Added joint events for when a joint force or torque exceeds a specified threshold.
Joint definitions now include a base `b2JointDef` for common properties. Joint definitions now use local frames (b2Transform) instead of bespoke local axes and reference angles.
The mouse and motor joints are now controlled by updating the joint frames.
Flipped order of arguments in b2RelativeAngle to match similar functions.
Improved joint debug draw.