### PR TITLE
[upstream] Added b2ContactId for events and access functions (https:/…

### DIFF
--- a/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
@@ -19,7 +19,7 @@ namespace Box2D.NET.Samples.Samples.Events;
 
 public class FootSensor : Sample
 {
-    private static readonly int SampleCharacterSensor = SampleFactory.Shared.RegisterSample("Events", "Foot Sensor", Create);
+    private static readonly int SampleFootSensor = SampleFactory.Shared.RegisterSample("Events", "Foot Sensor", Create);
 
     public const uint GROUND = 0x00000001;
     public const uint PLAYER = 0x00000002;

--- a/src/Box2D.NET.Samples/Samples/Events/JointEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/JointEvent.cs
@@ -12,7 +12,7 @@ using static Box2D.NET.B2Ids;
 using static Box2D.NET.B2Diagnostics;
 using static Box2D.NET.B2Worlds;
 
-namespace Box2D.NET.Samples.Samples.Joints;
+namespace Box2D.NET.Samples.Samples.Events;
 
 // This sample shows how to break joints when the internal reaction force becomes large. Instead of polling, this uses events.
 public class JointEvent : Sample

--- a/src/Box2D.NET.Samples/Samples/Events/PersistentContact.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/PersistentContact.cs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Ids;
+using static Box2D.NET.B2Worlds;
+using static Box2D.NET.B2Contacts;
+
+namespace Box2D.NET.Samples.Samples.Events;
+
+public class PersistentContact : Sample
+{
+    private static int SamplePersistentContact = SampleFactory.Shared.RegisterSample("Events", "Persistent Contact", Create);
+
+    private B2ContactId m_contactId;
+
+    private static Sample Create(SampleContext context)
+    {
+        return new PersistentContact(context);
+    }
+
+    public PersistentContact(SampleContext context) : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.0f, 6.0f);
+            m_context.camera.m_zoom = 7.5f;
+        }
+
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            B2BodyId groundId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Vec2[] points = new B2Vec2[22];
+            float x = 10.0f;
+            for (int i = 0; i < 20; ++i)
+            {
+                points[i] = new B2Vec2(x, 0.0f);
+                x -= 1.0f;
+            }
+
+            points[20] = new B2Vec2(-9.0f, 10.0f);
+            points[21] = new B2Vec2(10.0f, 10.0f);
+
+            B2ChainDef chainDef = b2DefaultChainDef();
+            chainDef.points = points;
+            chainDef.count = 22;
+            chainDef.isLoop = true;
+
+            b2CreateChain(groundId, ref chainDef);
+        }
+
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.type = B2BodyType.b2_dynamicBody;
+            bodyDef.position = new B2Vec2(-8.0f, 1.0f);
+            bodyDef.linearVelocity = new B2Vec2(2.0f, 0.0f);
+
+            B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.enableContactEvents = true;
+            B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.5f);
+            b2CreateCircleShape(bodyId, ref shapeDef, ref circle);
+        }
+
+        m_contactId = b2_nullContactId;
+    }
+
+    public override void Step()
+    {
+        base.Step();
+
+        B2ContactEvents events = b2World_GetContactEvents(m_worldId);
+        for (int i = 0; i < events.beginCount && i < 1; ++i)
+        {
+            B2ContactBeginTouchEvent @event = events.beginEvents[i];
+            m_contactId = events.beginEvents[i].contactId;
+        }
+
+        for (int i = 0; i < events.endCount; ++i)
+        {
+            if (B2_ID_EQUALS(m_contactId, events.endEvents[i].contactId))
+            {
+                m_contactId = b2_nullContactId;
+                break;
+            }
+        }
+
+        if (B2_IS_NON_NULL(m_contactId) && b2Contact_IsValid(m_contactId))
+        {
+            B2Manifold manifold = b2Contact_GetManifold(m_contactId);
+
+            for (int i = 0; i < manifold.pointCount; ++i)
+            {
+                ref readonly B2ManifoldPoint manifoldPoint = ref manifold.points[i];
+                B2Vec2 p1 = manifoldPoint.point;
+                B2Vec2 p2 = p1 + manifoldPoint.totalNormalImpulse * manifold.normal;
+                m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorCrimson);
+                m_draw.DrawPoint(p1, 6.0f, B2HexColor.b2_colorCrimson);
+                m_draw.DrawString(p1, $"{manifoldPoint.totalNormalImpulse:F2}");
+            }
+        }
+        else
+        {
+            m_contactId = b2_nullContactId;
+        }
+    }
+}

--- a/src/Box2D.NET/B2Contact.cs
+++ b/src/Box2D.NET/B2Contact.cs
@@ -34,6 +34,10 @@ namespace Box2D.NET
 
         // b2ContactFlags
         public uint flags;
+        
+        // This is monotonically advanced when a contact is allocated in this slot
+        // Used to check for invalid b2ContactId
+        public uint generation;
 
         public bool isMarked;
     }

--- a/src/Box2D.NET/B2ContactBeginTouchEvent.cs
+++ b/src/Box2D.NET/B2ContactBeginTouchEvent.cs
@@ -13,14 +13,20 @@ namespace Box2D.NET
         /// Id of the second shape
         public B2ShapeId shapeIdB;
 
+        /// The transient contact id. This contact maybe destroyed automatically by Box2D when the world is modified or simulated.
+        /// Used b2Contact_IsValid before using this id.
+        public B2ContactId contactId;
+
         /// The initial contact manifold. This is recorded before the solver is called,
-        /// so all the impulses will be zero.
+        /// so all the impulses will be zero. You can use the contact id to access the manifold impulses
+        /// using b2Contact_GetManifold.
         public B2Manifold manifold;
 
-        public B2ContactBeginTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, ref B2Manifold manifold)
+        public B2ContactBeginTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2ContactId contactId, ref B2Manifold manifold)
         {
             this.shapeIdA = shapeIdA;
             this.shapeIdB = shapeIdB;
+            this.contactId = contactId;
             this.manifold = manifold;
         }
     }

--- a/src/Box2D.NET/B2ContactEndTouchEvent.cs
+++ b/src/Box2D.NET/B2ContactEndTouchEvent.cs
@@ -19,11 +19,15 @@ namespace Box2D.NET
         ///	@warning this shape may have been destroyed
         ///	@see b2Shape_IsValid
         public B2ShapeId shapeIdB;
+        
+        /// Id of the contact
+        public B2ContactId contactId;
 
-        public B2ContactEndTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB)
+        public B2ContactEndTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2ContactId contactId)
         {
             this.shapeIdA = shapeIdA;
             this.shapeIdB = shapeIdB;
+            this.contactId = contactId;
         }
     }
 }

--- a/src/Box2D.NET/B2ContactId.cs
+++ b/src/Box2D.NET/B2ContactId.cs
@@ -1,0 +1,19 @@
+namespace Box2D.NET
+{
+    /// Contact id references a contact instance. This should be treated as an opaque handled.
+    public readonly struct B2ContactId
+    {
+        public readonly int index1;
+        public readonly ushort world0;
+        public readonly short padding;
+        public readonly uint generation;
+
+        public B2ContactId(int index1, ushort world0, short padding, uint generation)
+        {
+            this.index1 = index1;
+            this.world0 = world0;
+            this.padding = padding;
+            this.generation = generation;
+        }
+    }
+}

--- a/src/Box2D.NET/B2Ids.cs
+++ b/src/Box2D.NET/B2Ids.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Box2D.NET
@@ -41,6 +42,8 @@ namespace Box2D.NET
         public static readonly B2ShapeId b2_nullShapeId = new B2ShapeId(0, 0, 0);
         public static readonly B2ChainId b2_nullChainId = new B2ChainId(0, 0, 0);
         public static readonly B2JointId b2_nullJointId = new B2JointId(0, 0, 0);
+        public static readonly B2ContactId b2_nullContactId = new B2ContactId(0, 0, 0, 0);
+
 
         /// Macro to determine if any id is null.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -74,12 +77,18 @@ namespace Box2D.NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool B2_IS_NON_NULL(B2JointId id) => id.index1 != 0;
 
-        /// Compare two ids for equality. Doesn't work for b2WorldId.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool B2_IS_NON_NULL(B2ContactId id) => id.index1 != 0;
+
+        /// Compare two ids for equality. Doesn't work for b2WorldId. Don't mix types.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool B2_ID_EQUALS(B2BodyId id1, B2BodyId id2) => id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool B2_ID_EQUALS(B2ShapeId id1, B2ShapeId id2) => id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool B2_ID_EQUALS(B2ContactId id1, B2ContactId id2) => id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation;
 
         /// Store a world id into a uint32_t.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -156,6 +165,26 @@ namespace Box2D.NET
             return id;
         }
 
+        /// Store a contact id into 16 bytes
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void b2StoreContactId(B2ContactId id, Span<uint> values)
+        {
+            values[0] = (uint)id.index1;
+            values[1] = (uint)id.world0;
+            values[2] = (uint)id.generation;
+        }
+
+        /// Load a two uint64_t into a contact id.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static B2ContactId b2LoadContactId(Span<uint> values)
+        {
+            B2ContactId id = new B2ContactId((int)values[0], (ushort)values[1], 0, values[2]);
+            // id.index1 = (int32_t)values[0];
+            // id.world0 = (uint16_t)values[1];
+            // id.padding = 0;
+            // id.generation = (uint32_t)values[2];
+            return id;
+        }
 
         /**@}*/
     }

--- a/src/Box2D.NET/B2MotorJointDef.cs
+++ b/src/Box2D.NET/B2MotorJointDef.cs
@@ -5,7 +5,7 @@
 namespace Box2D.NET
 {
     /// A motor joint is used to control the relative motion between two bodies
-    ///
+    /// You may move local frame A to change the target transform.
     /// A typical usage is to control the movement of a dynamic body with respect to the ground.
     /// @ingroup motor_joint
     public struct B2MotorJointDef

--- a/src/Box2D.NET/B2MouseJointDef.cs
+++ b/src/Box2D.NET/B2MouseJointDef.cs
@@ -5,7 +5,7 @@
 namespace Box2D.NET
 {
     /// A mouse joint is used to make a point on a body track a specified world point.
-    ///
+    /// You may move local frame A to change the target point.
     /// This a soft constraint and allows the constraint to stretch without
     /// applying huge forces. This also applies rotation constraint heuristic to improve control.
     /// @ingroup mouse_joint

--- a/src/Box2D.NET/B2PrismaticJointDef.cs
+++ b/src/Box2D.NET/B2PrismaticJointDef.cs
@@ -6,10 +6,8 @@ namespace Box2D.NET
 {
     /// Prismatic joint definition
     ///
-    /// This requires defining a line of motion using an axis and an anchor point.
-    /// The definition uses local anchor points and a local axis so that the initial
-    /// configuration can violate the constraint slightly. The joint translation is zero
-    /// when the local anchor points coincide in world space.
+    /// Body B may slide along the x-axis in local frame A. Body B cannot rotate relative to body A.
+    /// The joint translation is zero when the local frame origins coincide in world space.
     /// @ingroup prismatic_joint
     public struct B2PrismaticJointDef
     {

--- a/src/Box2D.NET/B2RevoluteJointDef.cs
+++ b/src/Box2D.NET/B2RevoluteJointDef.cs
@@ -11,8 +11,7 @@ namespace Box2D.NET
     /// initial configuration can violate the constraint slightly. You also need to
     /// specify the initial relative angle for joint limits. This helps when saving
     /// and loading a game.
-    /// The local anchor points are measured from the body's origin
-    /// rather than the center of mass because:
+    /// The local anchor points are measured from the body's origin rather than the center of mass because:
     /// 1. you might not know where the center of mass will be
     /// 2. if you add/remove shapes from a body and recompute the mass, the joints will be broken
     /// @ingroup revolute_joint

--- a/src/Box2D.NET/B2WheelJointDef.cs
+++ b/src/Box2D.NET/B2WheelJointDef.cs
@@ -6,10 +6,8 @@ namespace Box2D.NET
 {
     /// Wheel joint definition
     ///
-    /// This requires defining a line of motion using an axis and an anchor point.
-    /// The definition uses local  anchor points and a local axis so that the initial
-    /// configuration can violate the constraint slightly. The joint translation is zero
-    /// when the local anchor points coincide in world space.
+    /// Body B is a wheel that may rotate freely and slide along the local x-axis in frame A.
+    /// The joint translation is zero when the local frame origins coincide in world space.
     /// @ingroup wheel_joint
     public struct B2WheelJointDef
     {


### PR DESCRIPTION
…/github.com/erincatto/box2d/commit/d3d2b926c6694f46f8d511ee90cb3f553bf488b2)

`b2ContactBeginTouchEvent` now contains a `b2ContactId` you can hold onto safely and query for the manifold. This lets you get the contact impulses. You can use the end touch event to clear the handle.