### PR TITLE
[upstream] Sensor hits (box2d #945)

### DIFF
--- a/src/Box2D.NET.Samples/Camera.cs
+++ b/src/Box2D.NET.Samples/Camera.cs
@@ -12,8 +12,8 @@ public class Camera
 {
     public B2Vec2 m_center;
     public float m_zoom;
-    public int m_width;
-    public int m_height;
+    public float m_width;
+    public float m_height;
 
     public Camera()
     {

--- a/src/Box2D.NET.Samples/Draw.cs
+++ b/src/Box2D.NET.Samples/Draw.cs
@@ -152,7 +152,7 @@ public class Draw
         m_solidCapsules.AddCapsule(p1, p2, radius, color);
     }
 
-    public void DrawSegment(B2Vec2 p1, B2Vec2 p2, B2HexColor color)
+    public void DrawLine(B2Vec2 p1, B2Vec2 p2, B2HexColor color)
     {
         m_lines.AddLine(p1, p2, color);
     }
@@ -205,7 +205,7 @@ public class Draw
         ImGui.End();
     }
 
-    public void DrawAABB(B2AABB aabb, B2HexColor c)
+    public void DrawBounds(B2AABB aabb, B2HexColor c)
     {
         B2Vec2 p1 = aabb.lowerBound;
         B2Vec2 p2 = new B2Vec2(aabb.upperBound.X, aabb.lowerBound.Y);
@@ -261,7 +261,7 @@ public class Draw
 
     public static void DrawSegmentFcn(B2Vec2 p1, B2Vec2 p2, B2HexColor color, object context)
     {
-        (context as Draw).DrawSegment(p1, p2, color);
+        (context as Draw).DrawLine(p1, p2, color);
     }
 
     public static void DrawTransformFcn(B2Transform transform, object context)

--- a/src/Box2D.NET.Samples/SampleApp.cs
+++ b/src/Box2D.NET.Samples/SampleApp.cs
@@ -41,7 +41,7 @@ public class SampleApp
     private SampleContext _context;
     private bool s_rightMouseDown = false;
     private B2Vec2 s_clickPointWS = b2Vec2_zero;
-    private float s_windowScale = 1.0f;
+    private float s_fontScale = 1.0f;
     private float s_framebufferScale = 1.0f;
     private float _frameTime = 0.0f;
 
@@ -100,7 +100,7 @@ public class SampleApp
                 }
                 else
                 {
-                    _context.glfw.GetMonitorContentScale(primaryMonitor, out s_windowScale, out s_windowScale);
+                    _context.glfw.GetMonitorContentScale(primaryMonitor, out s_fontScale, out s_fontScale);
                 }
             }
         }
@@ -109,13 +109,13 @@ public class SampleApp
         bool fullscreen = false;
         if (fullscreen)
         {
-            options.Size = new Vector2D<int>((int)(1920 * s_windowScale), (int)(1080 * s_windowScale));
-            //_ctx.g_mainWindow = _ctx.g_glfw.CreateWindow((int)(1920 * s_windowScale), (int)(1080 * s_windowScale), buffer, _ctx.g_glfw.GetPrimaryMonitor(), null);
+            options.Size = new Vector2D<int>((int)(1920), (int)(1080));
+            //_context.g_mainWindow = _context.g_glfw.CreateWindow((int)(1920 ), (int)(1080 ), buffer, _ctx.g_glfw.GetPrimaryMonitor(), null);
         }
         else
         {
-            options.Size = new Vector2D<int>((int)(_context.camera.m_width * s_windowScale), (int)(_context.camera.m_height * s_windowScale));
-            //_ctx.g_mainWindow = _ctx.g_glfw.CreateWindow((int)(_ctx.g_camera.m_width * s_windowScale), (int)(_ctx.g_camera.m_height * s_windowScale), buffer, null, null);
+            options.Size = new Vector2D<int>((int)(_context.camera.m_width), (int)(_context.camera.m_height));
+            //_context.g_mainWindow = _ctx.g_glfw.CreateWindow((int)(_ctx.g_camera.m_width * s_windowScale), (int)(_ctx.g_camera.m_height * s_windowScale), buffer, null, null);
         }
 
         _window = Window.Create(options);
@@ -157,11 +157,11 @@ public class SampleApp
     {
         var width = resize.X;
         var height = resize.Y;
-        _context.settings.windowWidth = (int)(width / s_windowScale);
-        _context.settings.windowHeight = (int)(height / s_windowScale);
+        _context.settings.windowWidth = width;
+        _context.settings.windowHeight = height;
 
-        _context.camera.m_width = (int)(width / s_windowScale);
-        _context.camera.m_height = (int)(height / s_windowScale);
+        _context.camera.m_width = width;
+        _context.camera.m_height = height;
     }
 
     private void OnWindowFrameBufferResize(Vector2D<int> resize)
@@ -196,14 +196,14 @@ public class SampleApp
                 return;
             }
 
-            // if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            // {
-            //     _ctx.g_glfw.GetWindowContentScale(_ctx.g_mainWindow, out s_framebufferScale, out s_framebufferScale);
-            // }
-            // else
-            // {
-            //     _ctx.g_glfw.GetWindowContentScale(_ctx.g_mainWindow, out s_windowScale, out s_windowScale);
-            // }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                //_context.glfw.GetWindowContentScale(_context.window, out s_framebufferScale, out s_framebufferScale);
+            }
+            else
+            {
+                //_context.glfw.GetWindowContentScale(_context.window, out s_fontScale, out s_fontScale);
+            }
 
             _context.glfw.MakeContextCurrent(_context.window);
         }
@@ -497,11 +497,13 @@ public class SampleApp
         // var imGuiIo = ImGui.GetIO();
         // var s = new ImFontConfig();
         // ImFontConfigPtr fontConfig = new ImFontConfigPtr(&s);
-        // fontConfig.RasterizerMultiply = s_windowScale * s_framebufferScale;
-        // _ctx.draw.m_smallFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 14.0f, fontConfig, IntPtr.Zero);
-        // _ctx.draw.m_regularFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 18.0f, fontConfig, IntPtr.Zero);
-        // _ctx.draw.m_mediumFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 40.0f, fontConfig, IntPtr.Zero);
-        // _ctx.draw.m_largeFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 64.0f, fontConfig, IntPtr.Zero);
+        // fontConfig.RasterizerMultiply = s_fontScale * s_framebufferScale;
+        // _context.draw.m_smallFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 14.0f * s_fontScale, fontConfig, IntPtr.Zero);
+        // _context.draw.m_regularFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 18.0f * s_fontScale, fontConfig, IntPtr.Zero);
+        // _context.draw.m_mediumFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 40.0f * s_fontScale, fontConfig, IntPtr.Zero);
+        // _context.draw.m_largeFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 64.0f * s_fontScale, fontConfig, IntPtr.Zero);
+
+        //imGuiIo.FontDefault = _context.draw.m_smallFont;
     }
 
     public void DestroyUI()
@@ -651,7 +653,7 @@ public class SampleApp
 
         double xd, yd;
         _context.glfw.GetCursorPos(_context.window, out xd, out yd);
-        B2Vec2 ps = new B2Vec2((float)(xd / s_windowScale), (float)(yd / s_windowScale));
+        B2Vec2 ps = new B2Vec2((float)(xd), (float)(yd));
 
         // Use the mouse to move things around.
         if (button == (int)MouseButton.Left)
@@ -684,7 +686,7 @@ public class SampleApp
 
     private unsafe void MouseMotionCallback(WindowHandle* window, double xd, double yd)
     {
-        B2Vec2 ps = new B2Vec2((float)(xd / s_windowScale), (float)(yd / s_windowScale));
+        B2Vec2 ps = new B2Vec2((float)(xd), (float)(yd));
 
         //ImGui_ImplGlfw_CursorPosCallback(window, ps.x, ps.y);
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
@@ -227,7 +227,7 @@ public class BenchmarkCast : Sample
 
             B2Vec2 p1 = m_origins[m_drawIndex];
             B2Vec2 p2 = p1 + m_translations[m_drawIndex];
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
             m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
             if (drawResult.hit)
@@ -266,7 +266,7 @@ public class BenchmarkCast : Sample
 
             B2Vec2 p1 = m_origins[m_drawIndex];
             B2Vec2 p2 = p1 + m_translations[m_drawIndex];
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
             m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
             if (drawResult.hit)
@@ -310,7 +310,7 @@ public class BenchmarkCast : Sample
                 B2Vec2 origin = m_origins[m_drawIndex];
                 B2AABB aabb = new B2AABB(origin - extent, origin + extent);
 
-                m_draw.DrawAABB(aabb, B2HexColor.b2_colorWhite);
+                m_draw.DrawBounds(aabb, B2HexColor.b2_colorWhite);
             }
 
             for (int i = 0; i < drawResult.count; ++i)

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkSensor.cs
@@ -10,6 +10,7 @@ using static Box2D.NET.B2Bodies;
 using static Box2D.NET.B2Shapes;
 using static Box2D.NET.Shared.RandomSupports;
 using static Box2D.NET.B2Worlds;
+using static Box2D.NET.B2Diagnostics;
 
 namespace Box2D.NET.Samples.Samples.Benchmarks;
 
@@ -19,16 +20,18 @@ public class BenchmarkSensor : Sample
 
     public class ShapeUserData
     {
-        public bool shouldDestroyVisitors;
+        public int row;
+        public bool active;
     };
 
     private const int m_columnCount = 40;
     private const int m_rowCount = 40;
     private int m_maxBeginCount;
     private int m_maxEndCount;
-    private ShapeUserData m_passiveSensor = new ShapeUserData();
+    private ShapeUserData[] m_passiveSensors = new ShapeUserData[m_rowCount];
     private ShapeUserData m_activeSensor = new ShapeUserData();
     private int m_lastStepCount;
+    private int m_filterRow;
 
     private static Sample Create(SampleContext context)
     {
@@ -43,8 +46,10 @@ public class BenchmarkSensor : Sample
             m_camera.m_zoom = 125.0f;
         }
 
-        m_passiveSensor.shouldDestroyVisitors = false;
-        m_activeSensor.shouldDestroyVisitors = true;
+        b2World_SetCustomFilterCallback(m_worldId, FilterFcn, this);
+
+        m_activeSensor.row = 0;
+        m_activeSensor.active = true;
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
         B2BodyId groundId = b2CreateBody(m_worldId, ref bodyDef);
@@ -76,18 +81,21 @@ public class BenchmarkSensor : Sample
             B2ShapeDef shapeDef = b2DefaultShapeDef();
             shapeDef.isSensor = true;
             shapeDef.enableSensorEvents = true;
-            shapeDef.userData = m_passiveSensor;
 
             float yStart = 10.0f;
 
             for (int j = 0; j < m_rowCount; ++j)
             {
+                m_passiveSensors[j] = new ShapeUserData();
+                m_passiveSensors[j].row = j;
+                m_passiveSensors[j].active = false;
+                shapeDef.userData = m_passiveSensors[j];
+
                 float y = j * shift + yStart;
                 for (int i = 0; i < m_columnCount; ++i)
                 {
                     float x = i * shift - xCenter;
-                    float yOffset = RandomFloatRange(-1.0f, 1.0f);
-                    B2Polygon box = b2MakeOffsetRoundedBox(0.5f, 0.5f, new B2Vec2(x, y + yOffset), RandomRot(), 0.1f);
+                    B2Polygon box = b2MakeOffsetRoundedBox(0.5f, 0.5f, new B2Vec2(x, y), b2Rot_identity, 0.1f);
                     b2CreatePolygonShape(groundId, ref shapeDef, ref box);
                 }
             }
@@ -96,6 +104,7 @@ public class BenchmarkSensor : Sample
         m_maxBeginCount = 0;
         m_maxEndCount = 0;
         m_lastStepCount = 0;
+        m_filterRow = m_rowCount >> 1;
     }
 
     void CreateRow(float y)
@@ -114,11 +123,39 @@ public class BenchmarkSensor : Sample
         B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.5f);
         for (int i = 0; i < m_columnCount; ++i)
         {
-            bodyDef.position = new B2Vec2(shift * i - xCenter, y);
+            // stagger bodies to avoid bunching up events into a single update
+            float yOffset = RandomFloatRange(-1.0f, 1.0f);
+            bodyDef.position = new B2Vec2(shift * i - xCenter, y + yOffset);
             B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
 
             b2CreateCircleShape(bodyId, ref shapeDef, ref circle);
         }
+    }
+
+    private bool Filter(B2ShapeId idA, B2ShapeId idB)
+    {
+        ShapeUserData userData = null;
+        if (b2Shape_IsSensor(idA))
+        {
+            userData = b2Shape_GetUserData(idA) as ShapeUserData;
+        }
+        else if (b2Shape_IsSensor(idB))
+        {
+            userData = b2Shape_GetUserData(idB) as ShapeUserData;
+        }
+
+        if (userData != null)
+        {
+            return userData.active == true || userData.row != m_filterRow;
+        }
+
+        return true;
+    }
+
+    private static bool FilterFcn(B2ShapeId idA, B2ShapeId idB, object context)
+    {
+        BenchmarkSensor self = context as BenchmarkSensor;
+        return self.Filter(idA, idB);
     }
 
     public override void Step()
@@ -139,12 +176,15 @@ public class BenchmarkSensor : Sample
 
             // shapes on begin touch are always valid
             ShapeUserData userData = (ShapeUserData)b2Shape_GetUserData(@event.sensorShapeId);
-            if (userData.shouldDestroyVisitors)
+            if (userData.active)
             {
                 zombies.Add(b2Shape_GetBody(@event.visitorShapeId));
             }
             else
             {
+                // Check custom filter correctness
+                B2_ASSERT(userData.row != m_filterRow);
+
                 // Modify color while overlapped with a sensor
                 B2SurfaceMaterial surfaceMaterial = b2Shape_GetSurfaceMaterial(@event.visitorShapeId);
                 surfaceMaterial.customColor = (uint)B2HexColor.b2_colorLime;

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
@@ -160,10 +160,10 @@ public class BenchmarkShapeDistance : Sample
         B2DistanceOutput output = m_outputs[m_drawIndex];
         m_draw.DrawSolidPolygon(ref xfA, m_polygonA.vertices.AsSpan(), m_polygonA.count, m_polygonA.radius, B2HexColor.b2_colorBox2DGreen);
         m_draw.DrawSolidPolygon(ref xfB, m_polygonB.vertices.AsSpan(), m_polygonB.count, m_polygonB.radius, B2HexColor.b2_colorBox2DBlue);
-        m_draw.DrawSegment(output.pointA, output.pointB, B2HexColor.b2_colorDimGray);
+        m_draw.DrawLine(output.pointA, output.pointB, B2HexColor.b2_colorDimGray);
         m_draw.DrawPoint(output.pointA, 10.0f, B2HexColor.b2_colorWhite);
         m_draw.DrawPoint(output.pointB, 10.0f, B2HexColor.b2_colorWhite);
-        m_draw.DrawSegment(output.pointA, output.pointA + 0.5f * output.normal, B2HexColor.b2_colorYellow);
+        m_draw.DrawLine(output.pointA, output.pointA + 0.5f * output.normal, B2HexColor.b2_colorYellow);
         DrawTextLine($"distance = {output.distance}");
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Bodies/Kinematic.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Kinematic.cs
@@ -78,7 +78,7 @@ public class Kinematic : Sample
             B2Rot rotation = b2MakeRot(2.0f * m_time);
 
             B2Vec2 axis = b2RotateVector(rotation, new B2Vec2(0.0f, 1.0f));
-            m_draw.DrawSegment(point - 0.5f * axis, point + 0.5f * axis, B2HexColor.b2_colorPlum);
+            m_draw.DrawLine(point - 0.5f * axis, point + 0.5f * axis, B2HexColor.b2_colorPlum);
             m_draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorPlum);
 
             b2Body_SetTargetTransform(m_bodyId, new B2Transform(point, rotation), m_timeStep);

--- a/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
@@ -135,7 +135,7 @@ public class Weeble : Sample
         B2Vec2 v2 = b2Body_GetWorldPointVelocity(m_weebleId, worldPoint);
 
         B2Vec2 offset = new B2Vec2(0.05f, 0.0f);
-        m_draw.DrawSegment(worldPoint, worldPoint + v1, B2HexColor.b2_colorRed);
-        m_draw.DrawSegment(worldPoint + offset, worldPoint + v2 + offset, B2HexColor.b2_colorGreen);
+        m_draw.DrawLine(worldPoint, worldPoint + v1, B2HexColor.b2_colorRed);
+        m_draw.DrawLine(worldPoint + offset, worldPoint + v2 + offset, B2HexColor.b2_colorGreen);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
+++ b/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
@@ -378,7 +378,7 @@ public class Mover : Sample
             m_pogoVelocity = 0.0f;
 
             B2Vec2 delta = translation;
-            m_draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
+            m_draw.DrawLine(origin, origin + delta, B2HexColor.b2_colorGray);
 
             if (m_pogoShape == (int)PogoShape.PogoPoint)
             {
@@ -390,7 +390,7 @@ public class Mover : Sample
             }
             else
             {
-                m_draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorGray);
+                m_draw.DrawLine(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorGray);
             }
         }
         else
@@ -401,7 +401,7 @@ public class Mover : Sample
             m_pogoVelocity = b2SpringDamper(m_pogoHertz, m_pogoDampingRatio, offset, m_pogoVelocity, timeStep);
 
             B2Vec2 delta = castResult.fraction * translation;
-            m_draw.DrawSegment(origin, origin + delta, B2HexColor.b2_colorGray);
+            m_draw.DrawLine(origin, origin + delta, B2HexColor.b2_colorGray);
 
             if (m_pogoShape == (int)PogoShape.PogoPoint)
             {
@@ -413,7 +413,7 @@ public class Mover : Sample
             }
             else
             {
-                m_draw.DrawSegment(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorPlum);
+                m_draw.DrawLine(segment.point1 + delta, segment.point2 + delta, B2HexColor.b2_colorPlum);
             }
 
             b2Body_ApplyForce(castResult.bodyId, new B2Vec2(0.0f, -50.0f), castResult.point, true);
@@ -623,7 +623,7 @@ public class Mover : Sample
             B2Vec2 p1 = m_transform.p + (plane.offset - m_capsule.radius) * plane.normal;
             B2Vec2 p2 = p1 + 0.1f * plane.normal;
             m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorYellow);
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorYellow);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorYellow);
         }
 
         {
@@ -632,7 +632,7 @@ public class Mover : Sample
 
             B2HexColor color = m_onGround ? B2HexColor.b2_colorOrange : B2HexColor.b2_colorAquamarine;
             m_draw.DrawSolidCapsule(p1, p2, m_capsule.radius, color);
-            m_draw.DrawSegment(m_transform.p, m_transform.p + m_velocity, B2HexColor.b2_colorPurple);
+            m_draw.DrawLine(m_transform.p, m_transform.p + m_velocity, B2HexColor.b2_colorPurple);
         }
 
         B2Vec2 p = m_transform.p;

--- a/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
@@ -389,13 +389,13 @@ public class CastWorld : Sample
             {
                 B2Vec2 c = b2MulAdd(m_rayStart, result.fraction, rayTranslation);
                 m_draw.DrawPoint(result.point, 5.0f, color1);
-                m_draw.DrawSegment(m_rayStart, c, color2);
+                m_draw.DrawLine(m_rayStart, c, color2);
                 B2Vec2 head = b2MulAdd(result.point, 0.5f, result.normal);
-                m_draw.DrawSegment(result.point, head, color3);
+                m_draw.DrawLine(result.point, head, color3);
             }
             else
             {
-                m_draw.DrawSegment(m_rayStart, m_rayEnd, color2);
+                m_draw.DrawLine(m_rayStart, m_rayEnd, color2);
             }
         }
         else
@@ -454,9 +454,9 @@ public class CastWorld : Sample
                     B2Vec2 p = context.points[i];
                     B2Vec2 n = context.normals[i];
                     m_draw.DrawPoint(p, 5.0f, colors[i]);
-                    m_draw.DrawSegment(m_rayStart, c, color2);
+                    m_draw.DrawLine(m_rayStart, c, color2);
                     B2Vec2 head = b2MulAdd(p, 1.0f, n);
-                    m_draw.DrawSegment(p, head, color3);
+                    m_draw.DrawLine(p, head, color3);
 
                     B2Vec2 t = b2MulSV(context.fractions[i], rayTranslation);
                     B2Transform shiftedTransform = new B2Transform(t, b2Rot_identity);
@@ -480,7 +480,7 @@ public class CastWorld : Sample
             else
             {
                 B2Transform shiftedTransform = new B2Transform(b2Add(transform.p, rayTranslation), transform.q);
-                m_draw.DrawSegment(m_rayStart, m_rayEnd, color2);
+                m_draw.DrawLine(m_rayStart, m_rayEnd, color2);
 
                 if (m_castType == CastType.e_circleCast)
                 {

--- a/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
@@ -315,11 +315,11 @@ public class DynamicTree : Sample
 
             if (p.queryStamp == m_timeStamp || p.rayStamp == m_timeStamp)
             {
-                m_draw.DrawAABB(p.box, qc);
+                m_draw.DrawBounds(p.box, qc);
             }
             else
             {
-                m_draw.DrawAABB(p.box, c);
+                m_draw.DrawBounds(p.box, c);
             }
 
             float moveTest = RandomFloatRange(0.0f, 1.0f);
@@ -429,7 +429,7 @@ public class DynamicTree : Sample
 
             b2DynamicTree_Query(m_tree, box, B2_DEFAULT_MASK_BITS, QueryCallback, ref dynamicTreeContext);
 
-            m_draw.DrawAABB(box, B2HexColor.b2_colorWhite);
+            m_draw.DrawBounds(box, B2HexColor.b2_colorWhite);
         }
 
         // m_startPoint = {-1.0f, 0.5f};
@@ -443,7 +443,7 @@ public class DynamicTree : Sample
             B2RayCastInput input = new B2RayCastInput(m_startPoint, b2Sub(m_endPoint, m_startPoint), 1.0f);
             B2TreeStats result = b2DynamicTree_RayCast(m_tree, ref input, B2_DEFAULT_MASK_BITS, RayCallback, ref dynamicTreeContext);
 
-            m_draw.DrawSegment(m_startPoint, m_endPoint, B2HexColor.b2_colorWhite);
+            m_draw.DrawLine(m_startPoint, m_endPoint, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(m_startPoint, 5.0f, B2HexColor.b2_colorGreen);
             m_draw.DrawPoint(m_endPoint, 5.0f, B2HexColor.b2_colorRed);
 

--- a/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
@@ -189,7 +189,7 @@ public class Manifold : Sample
 
             B2Vec2 p1 = mp.point;
             B2Vec2 p2 = b2MulAdd(p1, 0.5f, manifold.normal);
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorViolet);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorViolet);
 
             if (m_showAnchors)
             {
@@ -285,7 +285,7 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawLine(p1, p2, color1);
 
             m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
@@ -369,7 +369,7 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawLine(p1, p2, color1);
 
             p1 = b2TransformPoint(ref transform2, capsule.center1);
             p2 = b2TransformPoint(ref transform2, capsule.center2);
@@ -475,7 +475,7 @@ public class Manifold : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.point2);
-            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawLine(p1, p2, color1);
             m_draw.DrawSolidPolygon(ref transform2, rox.vertices.AsSpan(), rox.count, rox.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
@@ -573,9 +573,9 @@ public class Manifold : Sample
             B2Vec2 g2 = b2TransformPoint(ref transform1, segment.ghost2);
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.segment.point2);
-            m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-            m_draw.DrawSegment(p1, p2, color1);
-            m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+            m_draw.DrawLine(g1, p1, B2HexColor.b2_colorLightGray);
+            m_draw.DrawLine(p1, p2, color1);
+            m_draw.DrawLine(p2, g2, B2HexColor.b2_colorLightGray);
             m_draw.DrawSolidCircle(ref transform2, circle.center, circle.radius, color2);
 
             DrawManifold(ref m, transform1.p, transform2.p);
@@ -616,18 +616,18 @@ public class Manifold : Sample
                 B2Vec2 g2 = b2TransformPoint(ref transform1, segment1.ghost2);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment1.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment1.segment.point2);
-                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawLine(p1, p2, color1);
                 m_draw.DrawPoint(p1, 4.0f, color1);
                 m_draw.DrawPoint(p2, 4.0f, color1);
-                m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+                m_draw.DrawLine(p2, g2, B2HexColor.b2_colorLightGray);
             }
 
             {
                 B2Vec2 g1 = b2TransformPoint(ref transform1, segment2.ghost1);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment2.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment2.segment.point2);
-                m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawLine(g1, p1, B2HexColor.b2_colorLightGray);
+                m_draw.DrawLine(p1, p2, color1);
                 m_draw.DrawPoint(p1, 4.0f, color1);
                 m_draw.DrawPoint(p2, 4.0f, color1);
             }
@@ -672,18 +672,18 @@ public class Manifold : Sample
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment1.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment1.segment.point2);
                 // m_context.g_draw.DrawSegment(g1, p1, b2HexColor.b2_colorLightGray);
-                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawLine(p1, p2, color1);
                 m_draw.DrawPoint(p1, 4.0f, color1);
                 m_draw.DrawPoint(p2, 4.0f, color1);
-                m_draw.DrawSegment(p2, g2, B2HexColor.b2_colorLightGray);
+                m_draw.DrawLine(p2, g2, B2HexColor.b2_colorLightGray);
             }
 
             {
                 B2Vec2 g1 = b2TransformPoint(ref transform1, segment2.ghost1);
                 B2Vec2 p1 = b2TransformPoint(ref transform1, segment2.segment.point1);
                 B2Vec2 p2 = b2TransformPoint(ref transform1, segment2.segment.point2);
-                m_draw.DrawSegment(g1, p1, B2HexColor.b2_colorLightGray);
-                m_draw.DrawSegment(p1, p2, color1);
+                m_draw.DrawLine(g1, p1, B2HexColor.b2_colorLightGray);
+                m_draw.DrawLine(p1, p2, color1);
                 m_draw.DrawPoint(p1, 4.0f, color1);
                 m_draw.DrawPoint(p2, 4.0f, color1);
                 // m_context.g_draw.DrawSegment(p2, g2, b2HexColor.b2_colorLightGray);

--- a/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
@@ -194,12 +194,12 @@ public class RayCast : Sample
             else
             {
                 p = b2MulAdd(p1, output.fraction, d);
-                m_draw.DrawSegment(p1, p, B2HexColor.b2_colorWhite);
+                m_draw.DrawLine(p1, p, B2HexColor.b2_colorWhite);
                 m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
                 m_draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
 
                 B2Vec2 n = b2MulAdd(p, 1.0f, output.normal);
-                m_draw.DrawSegment(p, n, B2HexColor.b2_colorViolet);
+                m_draw.DrawLine(p, n, B2HexColor.b2_colorViolet);
             }
 
             if (m_showFraction)
@@ -210,7 +210,7 @@ public class RayCast : Sample
         }
         else
         {
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(p1, 5.0f, B2HexColor.b2_colorGreen);
             m_draw.DrawPoint(p2, 5.0f, B2HexColor.b2_colorRed);
         }
@@ -235,7 +235,7 @@ public class RayCast : Sample
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
             B2RayCastInput input = new B2RayCastInput(start, translation, maxFraction);
 
-            B2CastOutput localOutput = b2RayCastCircle(ref input, ref m_circle);
+            B2CastOutput localOutput = b2RayCastCircle(ref m_circle, ref input);
             if (localOutput.hit)
             {
                 output = localOutput;
@@ -258,7 +258,7 @@ public class RayCast : Sample
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
             B2RayCastInput input = new B2RayCastInput(start, translation, maxFraction);
 
-            B2CastOutput localOutput = b2RayCastCapsule(ref input, ref m_capsule);
+            B2CastOutput localOutput = b2RayCastCapsule(ref m_capsule, ref input);
             if (localOutput.hit)
             {
                 output = localOutput;
@@ -279,7 +279,7 @@ public class RayCast : Sample
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
             B2RayCastInput input = new B2RayCastInput(start, translation, maxFraction);
 
-            B2CastOutput localOutput = b2RayCastPolygon(ref input, ref m_box);
+            B2CastOutput localOutput = b2RayCastPolygon(ref m_box, ref input);
             if (localOutput.hit)
             {
                 output = localOutput;
@@ -300,7 +300,7 @@ public class RayCast : Sample
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
             B2RayCastInput input = new B2RayCastInput(start, translation, maxFraction);
 
-            B2CastOutput localOutput = b2RayCastPolygon(ref input, ref m_triangle);
+            B2CastOutput localOutput = b2RayCastPolygon(ref m_triangle, ref input);
             if (localOutput.hit)
             {
                 output = localOutput;
@@ -318,13 +318,13 @@ public class RayCast : Sample
 
             B2Vec2 p1 = b2TransformPoint(ref transform, m_segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform, m_segment.point2);
-            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawLine(p1, p2, color1);
 
             B2Vec2 start = b2InvTransformPoint(transform, m_rayStart);
             B2Vec2 translation = b2InvRotateVector(transform.q, b2Sub(m_rayEnd, m_rayStart));
             B2RayCastInput input = new B2RayCastInput(start, translation, maxFraction);
 
-            B2CastOutput localOutput = b2RayCastSegment(ref input, ref m_segment, false);
+            B2CastOutput localOutput = b2RayCastSegment(ref m_segment, ref input, false);
             if (localOutput.hit)
             {
                 output = localOutput;

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
@@ -209,7 +209,7 @@ public class ShapeCast : Sample
                 }
                 else
                 {
-                    m_draw.DrawSegment(p1, p2, color);
+                    m_draw.DrawLine(p1, p2, color);
                 }
             }
                 break;
@@ -391,7 +391,7 @@ public class ShapeCast : Sample
             if (output.fraction > 0.0f)
             {
                 m_draw.DrawPoint(output.point, 5.0f, B2HexColor.b2_colorWhite);
-                m_draw.DrawSegment(output.point, output.point + 0.5f * output.normal, B2HexColor.b2_colorYellow);
+                m_draw.DrawLine(output.point, output.point + 0.5f * output.normal, B2HexColor.b2_colorYellow);
             }
             else
             {

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
@@ -192,7 +192,7 @@ public class ShapeDistance : Sample
                 }
                 else
                 {
-                    m_draw.DrawSegment(p1, p2, color);
+                    m_draw.DrawLine(p1, p2, color);
                 }
             }
                 break;
@@ -402,7 +402,7 @@ public class ShapeDistance : Sample
                 B2Vec2 pointB = new B2Vec2();
                 ComputeSimplexWitnessPoints(ref pointA, ref pointB, ref simplex);
 
-                m_draw.DrawSegment(pointA, pointB, B2HexColor.b2_colorWhite);
+                m_draw.DrawLine(pointA, pointB, B2HexColor.b2_colorWhite);
                 m_draw.DrawPoint(pointA, 10.0f, B2HexColor.b2_colorWhite);
                 m_draw.DrawPoint(pointB, 10.0f, B2HexColor.b2_colorWhite);
             }
@@ -418,11 +418,11 @@ public class ShapeDistance : Sample
         }
         else
         {
-            m_draw.DrawSegment(_outputPointA, _outputPointB, B2HexColor.b2_colorDimGray);
+            m_draw.DrawLine(_outputPointA, _outputPointB, B2HexColor.b2_colorDimGray);
             m_draw.DrawPoint(_outputPointA, 10.0f, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(_outputPointB, 10.0f, B2HexColor.b2_colorWhite);
             
-            m_draw.DrawSegment( _outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow );
+            m_draw.DrawLine( _outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow );
         }
 
         if (m_showIndices)

--- a/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
@@ -229,7 +229,7 @@ public class SmoothManifold : Sample
 
             B2Vec2 p1 = mp.point;
             B2Vec2 p2 = b2MulAdd(p1, 0.5f, manifold.normal);
-            m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorWhite);
+            m_draw.DrawLine(p1, p2, B2HexColor.b2_colorWhite);
 
             if (m_showAnchors)
             {
@@ -271,7 +271,7 @@ public class SmoothManifold : Sample
             ref readonly B2ChainSegment segment = ref m_segments[i];
             B2Vec2 p1 = b2TransformPoint(ref transform1, segment.segment.point1);
             B2Vec2 p2 = b2TransformPoint(ref transform1, segment.segment.point2);
-            m_draw.DrawSegment(p1, p2, color1);
+            m_draw.DrawLine(p1, p2, color1);
             m_draw.DrawPoint(p1, 4.0f, color1);
         }
 

--- a/src/Box2D.NET.Samples/Samples/Continuous/BounceHumans.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/BounceHumans.cs
@@ -107,6 +107,6 @@ public class BounceHumans : Sample
     {
         base.Draw(settings);
 
-        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(3.0f * _cs1.sine, 3.0f * _cs2.cosine), B2HexColor.b2_colorWhite);
+        m_draw.DrawLine(b2Vec2_zero, new B2Vec2(3.0f * _cs1.sine, 3.0f * _cs2.cosine), B2HexColor.b2_colorWhite);
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Donut.cs
+++ b/src/Box2D.NET.Samples/Samples/Donut.cs
@@ -73,7 +73,7 @@ public struct Donut
         weldDef.angularDampingRatio = 0.0f;
         weldDef.@base.localFrameA.p = new B2Vec2(0.0f, 0.5f * length);
         weldDef.@base.localFrameB.p = new B2Vec2(0.0f, -0.5f * length);
-        weldDef.@base.drawSize = 0.5f * scale;
+        weldDef.@base.drawScale = 0.5f * scale;
 
         B2BodyId prevBodyId = m_bodyIds[m_sides - 1];
         for (int i = 0; i < m_sides; ++i)

--- a/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
@@ -232,7 +232,7 @@ public class ContactEvent : Sample
                         for (int k = 0; k < manifold.pointCount; ++k)
                         {
                             B2ManifoldPoint point = manifold.points[k];
-                            m_draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorBlueViolet);
+                            m_draw.DrawLine(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorBlueViolet);
                             m_draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
                         }
                     }
@@ -262,7 +262,7 @@ public class ContactEvent : Sample
                         for (int k = 0; k < manifold.pointCount; ++k)
                         {
                             B2ManifoldPoint point = manifold.points[k];
-                            m_draw.DrawSegment(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorYellowGreen);
+                            m_draw.DrawLine(point.point, point.point + point.totalNormalImpulse * normal, B2HexColor.b2_colorYellowGreen);
                             m_draw.DrawPoint(point.point, 10.0f, B2HexColor.b2_colorWhite);
                         }
                     }

--- a/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
@@ -29,7 +29,7 @@ public class FootSensor : Sample
 
     private B2BodyId m_playerId;
     private B2ShapeId m_sensorId;
-    private List<B2ShapeId> m_overlaps = new List<B2ShapeId>();
+    private List<B2SensorData> m_sensorData = new List<B2SensorData>();
     private int m_overlapCount;
 
     private static Sample Create(SampleContext context)
@@ -138,13 +138,13 @@ public class FootSensor : Sample
         base.Draw(settings);
 
         int capacity = b2Shape_GetSensorCapacity(m_sensorId);
-        m_overlaps.Clear();
-        m_overlaps.Resize(capacity);
+        m_sensorData.Clear();
+        m_sensorData.Resize(capacity);
 
-        int count = b2Shape_GetSensorOverlaps(m_sensorId, CollectionsMarshal.AsSpan(m_overlaps), capacity);
+        int count = b2Shape_GetSensorData(m_sensorId, CollectionsMarshal.AsSpan(m_sensorData), capacity);
         for (int i = 0; i < count; ++i)
         {
-            B2ShapeId shapeId = m_overlaps[i];
+            B2ShapeId shapeId = m_sensorData[i].visitorId;
             B2AABB aabb = b2Shape_GetAABB(shapeId);
             B2Vec2 point = b2AABB_Center(aabb);
             m_draw.DrawPoint(point, 10.0f, B2HexColor.b2_colorWhite);

--- a/src/Box2D.NET.Samples/Samples/Events/JointEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/JointEvent.cs
@@ -17,7 +17,8 @@ namespace Box2D.NET.Samples.Samples.Events;
 // This sample shows how to break joints when the internal reaction force becomes large. Instead of polling, this uses events.
 public class JointEvent : Sample
 {
-    private static readonly int SampleBreakableJoint = SampleFactory.Shared.RegisterSample("Events", "Joint", Create);
+    private static readonly int SampleJointEvent = SampleFactory.Shared.RegisterSample("Events", "Joint", Create);
+    
     public const int e_count = 6;
 
     private readonly B2JointId[] m_jointIds;
@@ -174,8 +175,6 @@ public class JointEvent : Sample
             jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.angularHertz = 2.0f;
             jointDef.angularDampingRatio = 0.5f;
-            jointDef.linearHertz = 2.0f;
-            jointDef.linearDampingRatio = 0.5f;
             jointDef.@base.forceThreshold = forceThreshold;
             jointDef.@base.torqueThreshold = torqueThreshold;
             jointDef.@base.collideConnected = true;

--- a/src/Box2D.NET.Samples/Samples/Events/PersistentContact.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/PersistentContact.cs
@@ -92,14 +92,14 @@ public class PersistentContact : Sample
 
         if (B2_IS_NON_NULL(m_contactId) && b2Contact_IsValid(m_contactId))
         {
-            B2Manifold manifold = b2Contact_GetManifold(m_contactId);
+            B2ContactData data = b2Contact_GetData(m_contactId);
 
-            for (int i = 0; i < manifold.pointCount; ++i)
+            for (int i = 0; i < data.manifold.pointCount; ++i)
             {
-                ref readonly B2ManifoldPoint manifoldPoint = ref manifold.points[i];
+                ref readonly B2ManifoldPoint manifoldPoint = ref data.manifold.points[i];
                 B2Vec2 p1 = manifoldPoint.point;
-                B2Vec2 p2 = p1 + manifoldPoint.totalNormalImpulse * manifold.normal;
-                m_draw.DrawSegment(p1, p2, B2HexColor.b2_colorCrimson);
+                B2Vec2 p2 = p1 + manifoldPoint.totalNormalImpulse * data.manifold.normal;
+                m_draw.DrawLine(p1, p2, B2HexColor.b2_colorCrimson);
                 m_draw.DrawPoint(p1, 6.0f, B2HexColor.b2_colorCrimson);
                 m_draw.DrawString(p1, $"{manifoldPoint.totalNormalImpulse:F2}");
             }

--- a/src/Box2D.NET.Samples/Samples/Events/SensorHits.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorHits.cs
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Numerics;
+using ImGuiNET;
+using Silk.NET.GLFW;
+using static Box2D.NET.B2Ids;
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2MathFunction;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Worlds;
+using static Box2D.NET.B2Joints;
+using static Box2D.NET.B2PrismaticJoints;
+using static Box2D.NET.Shared.RandomSupports;
+
+namespace Box2D.NET.Samples.Samples.Events;
+
+public class SensorHits : Sample
+{
+    private static readonly int SampleSensorHits = SampleFactory.Shared.RegisterSample("Events", "Sensor Hits", Create);
+
+    private B2ShapeId m_staticSensorId;
+    private B2ShapeId m_kinematicSensorId;
+    private B2ShapeId m_dynamicSensorId;
+
+    private B2BodyId m_kinematicBodyId;
+    private B2BodyId m_dynamicBodyId;
+    private B2JointId m_jointId;
+
+    private B2BodyId m_bodyId;
+    private B2ShapeId m_shapeId;
+
+    private const int m_transformCapacity = 20;
+    private int m_transformCount;
+    private B2Transform[] m_transforms = new B2Transform[m_transformCapacity];
+
+    private bool m_isBullet;
+    private bool m_enableSensorHits;
+    private int m_beginCount;
+    private int m_endCount;
+
+    private static Sample Create(SampleContext context)
+    {
+        return new SensorHits(context);
+    }
+
+    public SensorHits(SampleContext context) : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.0f, 5.0f);
+            m_context.camera.m_zoom = 7.5f;
+        }
+
+        B2BodyId groundId;
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "ground";
+
+            groundId = b2CreateBody(m_worldId, ref bodyDef);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+
+            B2Segment groundSegment = new B2Segment(new B2Vec2(-10.0f, 0.0f), new B2Vec2(10.0f, 0.0f));
+            b2CreateSegmentShape(groundId, ref shapeDef, ref groundSegment);
+
+            groundSegment = new B2Segment(new B2Vec2(10.0f, 0.0f), new B2Vec2(10.0f, 10.0f));
+            b2CreateSegmentShape(groundId, ref shapeDef, ref groundSegment);
+        }
+
+        // Static sensor
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "static sensor";
+            bodyDef.position = new B2Vec2(-4.0f, 1.0f);
+
+            B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.isSensor = true;
+            shapeDef.enableSensorEvents = true;
+
+            B2Segment segment = new B2Segment(new B2Vec2(0.0f, 0.0f), new B2Vec2(0.0f, 10.0f));
+            m_staticSensorId = b2CreateSegmentShape(bodyId, ref shapeDef, ref segment);
+        }
+
+        // Kinematic sensor
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "kinematic sensor";
+            bodyDef.type = B2BodyType.b2_kinematicBody;
+            bodyDef.position = new B2Vec2(0.0f, 1.0f);
+            bodyDef.linearVelocity = new B2Vec2(0.5f, 0.0f);
+
+            m_kinematicBodyId = b2CreateBody(m_worldId, ref bodyDef);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.isSensor = true;
+            shapeDef.enableSensorEvents = true;
+
+            B2Segment segment = new B2Segment(new B2Vec2(0.0f, 0.0f), new B2Vec2(0.0f, 10.0f));
+            m_kinematicSensorId = b2CreateSegmentShape(m_kinematicBodyId, ref shapeDef, ref segment);
+        }
+
+        // Dynamic sensor
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "dynamic sensor";
+            bodyDef.type = B2BodyType.b2_dynamicBody;
+            bodyDef.position = new B2Vec2(4.0f, 1.0f);
+
+            m_dynamicBodyId = b2CreateBody(m_worldId, ref bodyDef);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.isSensor = true;
+            shapeDef.enableSensorEvents = true;
+
+            B2Capsule capsule = new B2Capsule(new B2Vec2(0.0f, 1.0f), new B2Vec2(0.0f, 9.0f), 0.1f);
+            m_dynamicSensorId = b2CreateCapsuleShape(m_dynamicBodyId, ref shapeDef, ref capsule);
+
+            B2Vec2 pivot = bodyDef.position + new B2Vec2(0.0f, 6.0f);
+            B2Vec2 axis = new B2Vec2(1.0f, 0.0f);
+            B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
+            jointDef.@base.bodyIdA = groundId;
+            jointDef.@base.bodyIdB = m_dynamicBodyId;
+            jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector(axis);
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, pivot);
+            jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector(axis);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_dynamicBodyId, pivot);
+            jointDef.enableMotor = true;
+            jointDef.maxMotorForce = 1000.0f;
+            jointDef.motorSpeed = 0.5f;
+
+            m_jointId = b2CreatePrismaticJoint(m_worldId, ref jointDef);
+        }
+
+        m_beginCount = 0;
+        m_endCount = 0;
+        m_bodyId = new B2BodyId();
+        m_shapeId = new B2ShapeId();
+        m_transformCount = 0;
+        m_enableSensorHits = true;
+        m_isBullet = true;
+
+        Launch();
+    }
+
+    void Launch()
+    {
+        if (B2_IS_NON_NULL(m_bodyId))
+        {
+            b2DestroyBody(m_bodyId);
+        }
+
+        m_transformCount = 0;
+        m_beginCount = 0;
+        m_endCount = 0;
+
+        B2BodyDef bodyDef = b2DefaultBodyDef();
+        bodyDef.type = B2BodyType.b2_dynamicBody;
+        bodyDef.position = new B2Vec2(-26.7f, 6.0f);
+        float speed = RandomFloatRange(200.0f, 300.0f);
+        bodyDef.linearVelocity = new B2Vec2(speed, 0.0f);
+        bodyDef.isBullet = m_isBullet;
+        bodyDef.enableSensorHits = m_enableSensorHits;
+        m_bodyId = b2CreateBody(m_worldId, ref bodyDef);
+
+        B2ShapeDef shapeDef = b2DefaultShapeDef();
+        shapeDef.enableSensorEvents = true;
+        shapeDef.material.friction = 0.8f;
+        shapeDef.material.rollingResistance = 0.01f;
+        B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.25f);
+        m_shapeId = b2CreateCircleShape(m_bodyId, ref shapeDef, ref circle);
+    }
+
+    public override void UpdateGui()
+    {
+        float height = 120.0f;
+        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(120.0f, height));
+
+        ImGui.Begin("Sensor Hit", ImGuiWindowFlags.NoResize);
+
+        ImGui.Checkbox("Enable Hits", ref m_enableSensorHits);
+        ImGui.Checkbox("Bullet", ref m_isBullet);
+
+        if (ImGui.Button("Launch") || GetKey(Keys.B) == InputAction.Press)
+        {
+            Launch();
+        }
+
+        ImGui.End();
+    }
+
+    void CollectTransforms(B2ShapeId sensorShapeId)
+    {
+        const int capacity = 5;
+        Span<B2SensorData> sensorData = stackalloc B2SensorData[capacity];
+        int count = b2Shape_GetSensorData(sensorShapeId, sensorData, capacity);
+
+        for (int i = 0; i < count && m_transformCount < m_transformCapacity; ++i)
+        {
+            m_transforms[m_transformCount] = sensorData[i].visitTransform;
+            m_transformCount += 1;
+        }
+    }
+
+    public override void Step()
+    {
+        B2Vec2 p = b2Body_GetPosition(m_kinematicBodyId);
+        if (p.X > 1.0f)
+        {
+            b2Body_SetLinearVelocity(m_kinematicBodyId, new B2Vec2(-0.5f, 0.0f));
+        }
+        else if (p.X < -1.0f)
+        {
+            b2Body_SetLinearVelocity(m_kinematicBodyId, new B2Vec2(0.5f, 0.0f));
+        }
+
+        float x = b2PrismaticJoint_GetTranslation(m_jointId);
+        if (x > 1.0f)
+        {
+            b2PrismaticJoint_SetMotorSpeed(m_jointId, -0.5f);
+        }
+        else if (x < -1.0f)
+        {
+            b2PrismaticJoint_SetMotorSpeed(m_jointId, 0.5f);
+        }
+
+        base.Step();
+
+
+        B2SensorEvents sensorEvents = b2World_GetSensorEvents(m_worldId);
+        m_beginCount += sensorEvents.beginCount;
+        m_endCount += sensorEvents.endCount;
+
+        for (int i = 0; i < sensorEvents.beginCount; ++i)
+        {
+            ref readonly B2SensorBeginTouchEvent @event = ref sensorEvents.beginEvents[i];
+            CollectTransforms(@event.sensorShapeId);
+        }
+    }
+
+    public override void Draw(Settings settings)
+    {
+        base.Draw(settings);
+
+        for (int i = 0; i < m_transformCount; ++i)
+        {
+            m_draw.DrawTransform(m_transforms[i]);
+        }
+
+        DrawTextLine($"begin touch count = {m_beginCount}");
+        DrawTextLine($"end touch count = {m_endCount}");
+    }
+}

--- a/src/Box2D.NET.Samples/Samples/Events/SensorTypes.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorTypes.cs
@@ -29,7 +29,7 @@ public class SensorTypes : Sample
 
     private B2BodyId m_kinematicBodyId;
 
-    private List<B2ShapeId> m_overlaps = new List<B2ShapeId>();
+    private List<B2SensorData> m_sensorData = new List<B2SensorData>();
 
 
     private static Sample Create(SampleContext context)
@@ -142,16 +142,16 @@ public class SensorTypes : Sample
     {
         // Determine the necessary capacity
         int capacity = b2Shape_GetSensorCapacity(sensorShapeId);
-        m_overlaps.Resize(capacity);
+        m_sensorData.Resize(capacity);
 
         // Get all overlaps and record the actual count
-        int count = b2Shape_GetSensorOverlaps(sensorShapeId, CollectionsMarshal.AsSpan(m_overlaps), capacity);
-        m_overlaps.Resize(count);
+        int count = b2Shape_GetSensorData(sensorShapeId, CollectionsMarshal.AsSpan(m_sensorData), capacity);
+        m_sensorData.Resize(count);
 
         var builder = new StringBuilder();
         for (int i = 0; i < count; ++i)
         {
-            B2ShapeId visitorId = m_overlaps[i];
+            B2ShapeId visitorId = m_sensorData[i].visitorId;
             if (b2Shape_IsValid(visitorId) == false)
             {
                 continue;
@@ -199,7 +199,7 @@ public class SensorTypes : Sample
         B2Vec2 origin = new B2Vec2(5.0f, 1.0f);
         B2Vec2 translation = new B2Vec2(-10.0f, 0.0f);
         B2RayResult result = b2World_CastRayClosest(m_worldId, origin, translation, b2DefaultQueryFilter());
-        m_draw.DrawSegment(origin, origin + translation, B2HexColor.b2_colorDimGray);
+        m_draw.DrawLine(origin, origin + translation, B2HexColor.b2_colorDimGray);
 
         if (result.hit)
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
@@ -208,7 +208,7 @@ public class GearLift : Sample
                 jointDef.@base.bodyIdB = bodyId;
                 jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
                 jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
-                jointDef.@base.drawSize = 0.2f;
+                jointDef.@base.drawScale = 0.2f;
                 b2CreateRevoluteJoint(m_worldId, ref jointDef);
 
                 position.Y -= 2.0f * linkHalfLength;

--- a/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
@@ -76,7 +76,7 @@ public class PrismaticJoint : Sample
             jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector( axis );
             jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
             jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector( axis );
-            jointDef.@base.drawSize = 2.0f;
+            jointDef.@base.drawScale = 2.0f;
             jointDef.motorSpeed = m_motorSpeed;
             jointDef.maxMotorForce = m_motorForce;
             jointDef.enableMotor = m_enableMotor;

--- a/src/Box2D.NET.Samples/Samples/Joints/UserConstraint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/UserConstraint.cs
@@ -102,12 +102,12 @@ public class UserConstraint : Sample
             float C = length - slackLength;
             if (C < 0.0f || length < 0.001f)
             {
-                m_draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorLightCyan);
+                m_draw.DrawLine(anchorA, anchorB, B2HexColor.b2_colorLightCyan);
                 m_impulses[i] = 0.0f;
                 continue;
             }
 
-            m_draw.DrawSegment(anchorA, anchorB, B2HexColor.b2_colorViolet);
+            m_draw.DrawLine(anchorA, anchorB, B2HexColor.b2_colorViolet);
             B2Vec2 axis = b2Normalize(deltaAnchor);
 
             B2Vec2 rB = b2Sub(anchorB, pB);

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio1.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio1.cs
@@ -13,7 +13,7 @@ namespace Box2D.NET.Samples.Samples.Robustness;
 // Pyramid with heavy box on top
 public class HighMassRatio1 : Sample
 {
-    private static readonly int SampleIndex1 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio1", Create);
+    private static readonly int SampleHighMassRatio1 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio1", Create);
 
     private static Sample Create(SampleContext context)
     {

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio2.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio2.cs
@@ -13,7 +13,7 @@ namespace Box2D.NET.Samples.Samples.Robustness;
 // Big box on small boxes
 public class HighMassRatio2 : Sample
 {
-    private static readonly int SampleIndex2 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio2", Create);
+    private static readonly int SampleHighMassRatio2 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio2", Create);
 
     private static Sample Create(SampleContext context)
     {

--- a/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio3.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/HighMassRatio3.cs
@@ -14,7 +14,7 @@ namespace Box2D.NET.Samples.Samples.Robustness;
 // Big box on small triangles
 public class HighMassRatio3 : Sample
 {
-    private static readonly int SampleIndex3 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio3", Create);
+    private static readonly int SampleHighMassRatio3 = SampleFactory.Shared.RegisterSample("Robustness", "HighMassRatio3", Create);
 
     private static Sample Create(SampleContext context)
     {

--- a/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
@@ -15,14 +15,14 @@ namespace Box2D.NET.Samples.Samples.Robustness;
 
 public class OverlapRecovery : Sample
 {
-    private static readonly int SampleIndex4 = SampleFactory.Shared.RegisterSample("Robustness", "Overlap Recovery", Create);
+    private static readonly int SampleOverlapRecovery = SampleFactory.Shared.RegisterSample("Robustness", "Overlap Recovery", Create);
 
     private B2BodyId[] m_bodyIds;
     private int m_bodyCount;
     private int m_baseCount;
     private float m_overlap;
     private float m_extent;
-    private float m_pushOut;
+    private float m_speed;
     private float m_hertz;
     private float m_dampingRatio;
 
@@ -44,18 +44,14 @@ public class OverlapRecovery : Sample
         m_baseCount = 4;
         m_overlap = 0.25f;
         m_extent = 0.5f;
-        m_pushOut = 3.0f;
+        m_speed = 3.0f;
         m_hertz = 30.0f;
         m_dampingRatio = 10.0f;
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
         B2BodyId groundId = b2CreateBody(m_worldId, ref bodyDef);
-
-        float groundWidth = 40.0f;
         B2ShapeDef shapeDef = b2DefaultShapeDef();
-        shapeDef.density = 1.0f;
-
-        B2Segment segment = new B2Segment(new B2Vec2(-groundWidth, 0.0f), new B2Vec2(groundWidth, 0.0f));
+        B2Segment segment = new B2Segment(new B2Vec2(-40.0f, 0.0f), new B2Vec2(40.0f, 0.0f));
         b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
 
         CreateScene();
@@ -69,7 +65,7 @@ public class OverlapRecovery : Sample
             b2DestroyBody(m_bodyIds[i]);
         }
 
-        b2World_SetContactTuning(m_worldId, m_hertz, m_dampingRatio, m_pushOut);
+        b2World_SetContactTuning(m_worldId, m_hertz, m_dampingRatio, m_speed);
 
         B2BodyDef bodyDef = b2DefaultBodyDef();
         bodyDef.type = B2BodyType.b2_dynamicBody;
@@ -120,7 +116,7 @@ public class OverlapRecovery : Sample
         changed = changed || ImGui.SliderFloat("Extent", ref m_extent, 0.1f, 1.0f, "%.1f");
         changed = changed || ImGui.SliderInt("Base Count", ref m_baseCount, 1, 10);
         changed = changed || ImGui.SliderFloat("Overlap", ref m_overlap, 0.0f, 1.0f, "%.2f");
-        changed = changed || ImGui.SliderFloat("Speed", ref m_pushOut, 0.0f, 10.0f, "%.1f");
+        changed = changed || ImGui.SliderFloat("Speed", ref m_speed, 0.0f, 10.0f, "%.1f");
         changed = changed || ImGui.SliderFloat("Hertz", ref m_hertz, 0.0f, 240.0f, "%.f");
         changed = changed || ImGui.SliderFloat("Damping Ratio", ref m_dampingRatio, 0.0f, 20.0f, "%.1f");
         changed = changed || ImGui.Button("Reset Scene");

--- a/src/Box2D.NET.Samples/Samples/Sample.cs
+++ b/src/Box2D.NET.Samples/Samples/Sample.cs
@@ -466,13 +466,6 @@ public class Sample : IDisposable
 
         m_context.draw.m_debugDraw.drawingBounds = m_camera.GetViewBounds();
         m_context.draw.m_debugDraw.useDrawingBounds = settings.useCameraBounds;
-
-        // todo testing
-        // b2Transform t1 = {m_context.g_draw.m_debugDraw.drawingBounds.lowerBound, b2Rot_identity};
-        // b2Transform t2 = {m_context.g_draw.m_debugDraw.drawingBounds.upperBound, b2Rot_identity};
-        // m_context.g_draw.DrawSolidCircle(ref t1, b2Vec2_zero, 1.0f, {1.0f, 0.0f, 0.0f, 1.0f});
-        // m_context.g_draw.DrawSolidCircle(ref t2, b2Vec2_zero, 1.0f, {1.0f, 0.0f, 0.0f, 1.0f});
-
         m_context.draw.m_debugDraw.drawShapes = settings.drawShapes;
         m_context.draw.m_debugDraw.drawJoints = settings.drawJoints;
         m_context.draw.m_debugDraw.drawJointExtras = settings.drawJointExtras;

--- a/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
@@ -183,8 +183,8 @@ public class ChainShape : Sample
     {
         base.UpdateGui();
 
-        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.5f, 0.0f), B2HexColor.b2_colorRed);
-        m_draw.DrawSegment(b2Vec2_zero, new B2Vec2(0.0f, 0.5f), B2HexColor.b2_colorGreen);
+        m_draw.DrawLine(b2Vec2_zero, new B2Vec2(0.5f, 0.0f), B2HexColor.b2_colorRed);
+        m_draw.DrawLine(b2Vec2_zero, new B2Vec2(0.0f, 0.5f), B2HexColor.b2_colorGreen);
 
         // DrawTextLine($"toi calls, hits = {b2_toiCalls}, {b2_toiHitCount}");
 

--- a/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
@@ -220,16 +220,16 @@ public class CompoundShapes : Sample
         if (m_drawBodyAABBs)
         {
             B2AABB aabb = b2Body_ComputeAABB(m_table1Id);
-            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawBounds(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_table2Id);
-            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawBounds(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_ship1Id);
-            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawBounds(aabb, B2HexColor.b2_colorYellow);
 
             aabb = b2Body_ComputeAABB(m_ship2Id);
-            m_draw.DrawAABB(aabb, B2HexColor.b2_colorYellow);
+            m_draw.DrawBounds(aabb, B2HexColor.b2_colorYellow);
         }
     }
 }

--- a/src/Box2D.NET.Shared/Determinism.cs
+++ b/src/Box2D.NET.Shared/Determinism.cs
@@ -58,7 +58,7 @@ namespace Box2D.NET.Shared
                 jointDef.dampingRatio = 0.5f;
                 jointDef.@base.localFrameA.p = new B2Vec2(h, h);
                 jointDef.@base.localFrameB.p = new B2Vec2(offset, -h);
-                jointDef.@base.drawSize = 0.1f;
+                jointDef.@base.drawScale = 0.1f;
 
                 int bodyIndex = 0;
 

--- a/src/Box2D.NET.Shared/Humans.cs
+++ b/src/Box2D.NET.Shared/Humans.cs
@@ -131,7 +131,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -174,7 +174,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -213,7 +213,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -269,7 +269,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -308,7 +308,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -355,7 +355,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -394,7 +394,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -434,7 +434,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -473,7 +473,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }
@@ -513,7 +513,7 @@ namespace Box2D.NET.Shared
                 jointDef.enableSpring = hertz > 0.0f;
                 jointDef.hertz = hertz;
                 jointDef.dampingRatio = dampingRatio;
-                jointDef.@base.drawSize = drawSize;
+                jointDef.@base.drawScale = drawSize;
 
                 bone.jointId = b2CreateRevoluteJoint(worldId, ref jointDef);
             }

--- a/src/Box2D.NET/B2Bodies.cs
+++ b/src/Box2D.NET/B2Bodies.cs
@@ -268,6 +268,7 @@ namespace Box2D.NET
             bodySim.gravityScale = def.gravityScale;
             bodySim.bodyId = bodyId;
             bodySim.isBullet = def.isBullet;
+            bodySim.enableSensorHits = def.enableSensorHits;
             bodySim.allowFastRotation = def.allowFastRotation;
 
             if (setId == (int)B2SetType.b2_awakeSet)
@@ -493,6 +494,7 @@ namespace Box2D.NET
                     B2Shape shapeA = b2Array_Get(ref world.shapes, contact.shapeIdA);
                     B2Shape shapeB = b2Array_Get(ref world.shapes, contact.shapeIdB);
 
+                    contactData[index].contactId = new B2ContactId(contact.contactId + 1, bodyId.world0, 0, contact.generation);
                     contactData[index].shapeIdA = new B2ShapeId(shapeA.id + 1, bodyId.world0, shapeA.generation);
                     contactData[index].shapeIdB = new B2ShapeId(shapeB.id + 1, bodyId.world0, shapeB.generation);
 
@@ -680,6 +682,7 @@ namespace Box2D.NET
             return b2TransformPoint(ref transform, localPoint);
         }
 
+        /// Get a local vector on a body given a world vector
         public static B2Vec2 b2Body_GetLocalVector(B2BodyId bodyId, B2Vec2 worldVector)
         {
             B2World world = b2GetWorld(bodyId.world0);
@@ -688,6 +691,7 @@ namespace Box2D.NET
             return b2InvRotateVector(transform.q, worldVector);
         }
 
+        /// Get the world transform of a body.
         public static B2Vec2 b2Body_GetWorldVector(B2BodyId bodyId, B2Vec2 localVector)
         {
             B2World world = b2GetWorld(bodyId.world0);
@@ -696,6 +700,9 @@ namespace Box2D.NET
             return b2RotateVector(transform.q, localVector);
         }
 
+        /// Set the world transform of a body. This acts as a teleport and is fairly expensive.
+        /// @note Generally you should create a body with then intended transform.
+        /// @see b2BodyDef::position and b2BodyDef::rotation
         public static void b2Body_SetTransform(B2BodyId bodyId, B2Vec2 position, B2Rot rotation)
         {
             B2_ASSERT(b2IsValidVec2(position));
@@ -1301,6 +1308,7 @@ namespace Box2D.NET
             b2ValidateSolverSets(world);
         }
 
+        /// Set the body name. Up to 31 characters excluding 0 termination.
         public static void b2Body_SetName(B2BodyId bodyId, string name)
         {
             B2World world = b2GetWorld(bodyId.world0);
@@ -1316,6 +1324,7 @@ namespace Box2D.NET
             }
         }
 
+        /// Get the body name.
         public static string b2Body_GetName(B2BodyId bodyId)
         {
             B2World world = b2GetWorld(bodyId.world0);
@@ -1323,6 +1332,7 @@ namespace Box2D.NET
             return body.name;
         }
 
+        /// Set the user data for a body
         public static void b2Body_SetUserData(B2BodyId bodyId, object userData)
         {
             B2World world = b2GetWorld(bodyId.world0);
@@ -1330,6 +1340,7 @@ namespace Box2D.NET
             body.userData = userData;
         }
 
+        /// Get the user data stored in a body
         public static object b2Body_GetUserData(B2BodyId bodyId)
         {
             B2World world = b2GetWorld(bodyId.world0);

--- a/src/Box2D.NET/B2BodyDef.cs
+++ b/src/Box2D.NET/B2BodyDef.cs
@@ -65,8 +65,14 @@ namespace Box2D.NET
         /// Treat this body as high speed object that performs continuous collision detection
         /// against dynamic and kinematic bodies, but not other bullet bodies.
         /// @warning Bullets should be used sparingly. They are not a solution for general dynamic-versus-dynamic
-        /// continuous collision. They may interfere with joint constraints.
+        /// continuous collision.
         public bool isBullet;
+        
+        /// Option to perform continuous collision checks with sensors. This only applies to dynamic bodies.
+        /// This is expensive and should be used sparingly. You still need to enable sensor events on the child shapes
+        /// for this to work. This only works if the body is awake. This will use a time of impact calculation to
+        /// generate sensor begin touch events, but not end events. End events are handled using regular overlap checks.
+        public bool enableSensorHits;
 
         /// Used to disable a body. A disabled body does not move or collide.
         public bool isEnabled;

--- a/src/Box2D.NET/B2BodyMoveEvent.cs
+++ b/src/Box2D.NET/B2BodyMoveEvent.cs
@@ -16,9 +16,9 @@ namespace Box2D.NET
     /// @note If sleeping is disabled all dynamic and kinematic bodies will trigger move events.
     public struct B2BodyMoveEvent
     {
+        public object userData;
         public B2Transform transform;
         public B2BodyId bodyId;
-        public object userData;
         public bool fellAsleep;
     }
 }

--- a/src/Box2D.NET/B2BodySim.cs
+++ b/src/Box2D.NET/B2BodySim.cs
@@ -42,6 +42,7 @@ namespace Box2D.NET
         public bool isFast;
 
         public bool isBullet;
+        public bool enableSensorHits;
         public bool isSpeedCapped;
         public bool allowFastRotation;
         public bool enlargeAABB;

--- a/src/Box2D.NET/B2Constants.cs
+++ b/src/Box2D.NET/B2Constants.cs
@@ -47,13 +47,9 @@ namespace Box2D.NET
         // The time that a body must be still before it will go to sleep. In seconds.
         public const float B2_TIME_TO_SLEEP = 0.5f;
         
-        // The default joint constraint hertz
-        public const float B2_JOINT_CONSTRAINT_HERTZ = 60.0f;
-
-        // The default joint constraint damping ratio
-        public const float B2_JOINT_CONSTRAINT_DAMPING_RATIO = 0.0f;
-
-
+        // solver
+        public const int B2_MAX_CONTINUOUS_SENSOR_HITS = 8;
+        
         // collision
         // -----------------------------------------------------------------------------------------------------------------
         /// The maximum number of vertices on a convex polygon. Changing this affects performance even if you

--- a/src/Box2D.NET/B2ContactBeginTouchEvent.cs
+++ b/src/Box2D.NET/B2ContactBeginTouchEvent.cs
@@ -13,21 +13,15 @@ namespace Box2D.NET
         /// Id of the second shape
         public B2ShapeId shapeIdB;
 
-        /// The transient contact id. This contact maybe destroyed automatically by Box2D when the world is modified or simulated.
+        /// The transient contact id. This contact maybe destroyed automatically when the world is modified or simulated.
         /// Used b2Contact_IsValid before using this id.
         public B2ContactId contactId;
 
-        /// The initial contact manifold. This is recorded before the solver is called,
-        /// so all the impulses will be zero. You can use the contact id to access the manifold impulses
-        /// using b2Contact_GetManifold.
-        public B2Manifold manifold;
-
-        public B2ContactBeginTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2ContactId contactId, ref B2Manifold manifold)
+        public B2ContactBeginTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2ContactId contactId)
         {
             this.shapeIdA = shapeIdA;
             this.shapeIdB = shapeIdB;
             this.contactId = contactId;
-            this.manifold = manifold;
         }
     }
 }

--- a/src/Box2D.NET/B2ContactData.cs
+++ b/src/Box2D.NET/B2ContactData.cs
@@ -9,8 +9,17 @@ namespace Box2D.NET
     /// @see b2Shape_GetContactData() and b2Body_GetContactData()
     public struct B2ContactData
     {
+        public B2ContactId contactId;
         public B2ShapeId shapeIdA;
         public B2ShapeId shapeIdB;
         public B2Manifold manifold;
+
+        public B2ContactData(B2ContactId contactId, B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2Manifold manifold)
+        {
+            this.contactId = contactId;
+            this.shapeIdA = shapeIdA;
+            this.shapeIdB = shapeIdB;
+            this.manifold = manifold;
+        }
     }
 }

--- a/src/Box2D.NET/B2ContactEndTouchEvent.cs
+++ b/src/Box2D.NET/B2ContactEndTouchEvent.cs
@@ -20,7 +20,9 @@ namespace Box2D.NET
         ///	@see b2Shape_IsValid
         public B2ShapeId shapeIdB;
         
-        /// Id of the contact
+        /// Id of the contact.
+        ///	@warning this contact may have been destroyed
+        ///	@see b2Contact_IsValid
         public B2ContactId contactId;
 
         public B2ContactEndTouchEvent(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2ContactId contactId)

--- a/src/Box2D.NET/B2ContinuousContext.cs
+++ b/src/Box2D.NET/B2ContinuousContext.cs
@@ -12,5 +12,8 @@ namespace Box2D.NET
         public B2Vec2 centroid1, centroid2;
         public B2Sweep sweep;
         public float fraction;
+        public B2FixedArray8<B2SensorHit> sensorHits; // B2_MAX_CONTINUOUS_SENSOR_HITS
+        public B2FixedArray8<float> sensorFractions; // B2_MAX_CONTINUOUS_SENSOR_HITS
+        public int sensorCount;
     }
 }

--- a/src/Box2D.NET/B2Cores.cs
+++ b/src/Box2D.NET/B2Cores.cs
@@ -17,7 +17,11 @@ namespace Box2D.NET
         /// Get the current version of Box2D
         public static B2Version b2GetVersion()
         {
-            return new B2Version(3, 1, 1);
+            return new B2Version(
+                major: 3,
+                minor: 2,
+                revision: 0
+            );
         }
 
         // This allows the user to change the length units at runtime

--- a/src/Box2D.NET/B2Delegates.cs
+++ b/src/Box2D.NET/B2Delegates.cs
@@ -92,7 +92,7 @@ namespace Box2D.NET
     /// Return false if you want to disable the contact this step
     /// @warning Do not attempt to modify the world inside this callback
     /// @ingroup world
-    public delegate bool b2PreSolveFcn(B2ShapeId shapeIdA, B2ShapeId shapeIdB, ref B2Manifold manifold, object context);
+    public delegate bool b2PreSolveFcn(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2Vec2 point, B2Vec2 normal, object context);
 
     /// Prototype callback for overlap queries.
     /// Called for each shape found in the query.

--- a/src/Box2D.NET/B2DistanceJointDef.cs
+++ b/src/Box2D.NET/B2DistanceJointDef.cs
@@ -5,11 +5,8 @@
 namespace Box2D.NET
 {
     /// Distance joint definition
-    ///
-    /// This requires defining an anchor point on both
-    /// bodies and the non-zero distance of the distance joint. The definition uses
-    /// local anchor points so that the initial configuration can violate the
-    /// constraint slightly. This helps when saving and loading a game.
+    /// Connects a point on body A with a point on body B by a segment.
+    /// Useful for ropes and springs.
     /// @ingroup distance_joint
     public struct B2DistanceJointDef
     {

--- a/src/Box2D.NET/B2Distances.cs
+++ b/src/Box2D.NET/B2Distances.cs
@@ -687,7 +687,7 @@ namespace Box2D.NET
             B2CastOutput output = new B2CastOutput();
 
             int iteration = 0;
-            int maxIterations = 20;
+            const int maxIterations = 20;
             for (; iteration < maxIterations; ++iteration)
             {
                 output.iterations += 1;
@@ -1196,8 +1196,6 @@ namespace Box2D.NET
             float tMax = input.maxFraction;
 
             float totalRadius = proxyA.radius + proxyB.radius;
-            // todo_erin consider different target
-            // float target = b2MaxFloat( B2_LINEAR_SLOP, totalRadius );
             float target = b2MaxFloat(B2_LINEAR_SLOP, totalRadius - B2_LINEAR_SLOP);
             float tolerance = 0.25f * B2_LINEAR_SLOP;
             B2_ASSERT(target > tolerance);
@@ -1265,6 +1263,11 @@ namespace Box2D.NET
 #if B2_SNOOP_TOI_COUNTERS
                     b2_toiHitCount += 1;
 #endif
+                    // Averaged hit point
+                    B2Vec2 pA = b2MulAdd(distanceOutput.pointA, proxyA.radius, distanceOutput.normal);
+                    B2Vec2 pB = b2MulAdd(distanceOutput.pointB, -proxyB.radius, distanceOutput.normal);
+                    output.point = b2Lerp(pA, pB, 0.5f);
+                    output.normal = distanceOutput.normal;
                     output.fraction = t1;
                     break;
                 }
@@ -1353,6 +1356,11 @@ namespace Box2D.NET
 #if B2_SNOOP_TOI_COUNTERS
                         b2_toiHitCount += 1;
 #endif
+                        // Averaged hit point
+                        B2Vec2 pA = b2MulAdd(distanceOutput.pointA, proxyA.radius, distanceOutput.normal);
+                        B2Vec2 pB = b2MulAdd(distanceOutput.pointB, -proxyB.radius, distanceOutput.normal);
+                        output.point = b2Lerp(pA, pB, 0.5f);
+                        output.normal = distanceOutput.normal;
                         output.fraction = t1;
                         done = true;
                         break;
@@ -1433,6 +1441,11 @@ namespace Box2D.NET
 #if B2_SNOOP_TOI_COUNTERS
                     b2_toiFailedCount += 1;
 #endif
+                    // Averaged hit point
+                    B2Vec2 pA = b2MulAdd(distanceOutput.pointA, proxyA.radius, distanceOutput.normal);
+                    B2Vec2 pB = b2MulAdd(distanceOutput.pointB, -proxyB.radius, distanceOutput.normal);
+                    output.point = b2Lerp(pA, pB, 0.5f);
+                    output.normal = distanceOutput.normal;
                     output.fraction = t1;
                     break;
                 }

--- a/src/Box2D.NET/B2Ids.cs
+++ b/src/Box2D.NET/B2Ids.cs
@@ -37,7 +37,6 @@ namespace Box2D.NET
         /// Use these to make your identifiers null.
         /// You may also use zero initialization to get null.
         public static readonly B2WorldId b2_nullWorldId = new B2WorldId(0, 0);
-
         public static readonly B2BodyId b2_nullBodyId = new B2BodyId(0, 0, 0);
         public static readonly B2ShapeId b2_nullShapeId = new B2ShapeId(0, 0, 0);
         public static readonly B2ChainId b2_nullChainId = new B2ChainId(0, 0, 0);

--- a/src/Box2D.NET/B2Joint.cs
+++ b/src/Box2D.NET/B2Joint.cs
@@ -28,7 +28,7 @@ namespace Box2D.NET
         public int islandPrev;
         public int islandNext;
 
-        public float drawSize;
+        public float drawScale;
 
         public B2JointType type;
 

--- a/src/Box2D.NET/B2JointDef.cs
+++ b/src/Box2D.NET/B2JointDef.cs
@@ -1,5 +1,9 @@
 ﻿namespace Box2D.NET
 {
+    /// Base joint definition used by all joint types.
+    /// The local frames are measured from the body's origin rather than the center of mass because:
+    /// 1. you might not know where the center of mass will be
+    /// 2. if you add/remove shapes from a body and recompute the mass, the joints will be broken
     public struct B2JointDef
     {
         /// User data pointer
@@ -23,8 +27,14 @@
         /// Torque threshold for joint events
         public float torqueThreshold;
 
-        /// Debug draw size
-        public float drawSize;
+        /// Constraint hertz (advanced feature)
+        public float constraintHertz;
+
+        /// Constraint damping ratio (advanced feature)
+        public float constraintDampingRatio;
+
+        /// Debug draw scale
+        public float drawScale;
 
         /// Set this flag to true if the attached bodies should collide
         public bool collideConnected; 

--- a/src/Box2D.NET/B2JointEvent.cs
+++ b/src/Box2D.NET/B2JointEvent.cs
@@ -4,7 +4,10 @@
     /// The observed forces and torques are not returned for efficiency reasons.
     public struct B2JointEvent
     {
+        /// The joint id
         public B2JointId jointId;
+
+        /// The user data from the joint for convenience
         public object userData;
     }
 }

--- a/src/Box2D.NET/B2JointEvents.cs
+++ b/src/Box2D.NET/B2JointEvents.cs
@@ -1,6 +1,6 @@
 ﻿namespace Box2D.NET
 {
-    /// Joint events are buffered in the Box2D world and are available
+    /// Joint events are buffered in the world and are available
     /// as event arrays after the time step is complete.
     /// Note: this data becomes invalid if joints are destroyed
     public readonly struct B2JointEvents

--- a/src/Box2D.NET/B2MouseJoint.cs
+++ b/src/Box2D.NET/B2MouseJoint.cs
@@ -21,6 +21,6 @@ namespace Box2D.NET
         public B2Transform frameB;
         public B2Vec2 deltaCenter;
         public B2Mat22 linearMass;
-        public float axialMass;
+        public float angularMass;
     }
 }

--- a/src/Box2D.NET/B2MouseJointDef.cs
+++ b/src/Box2D.NET/B2MouseJointDef.cs
@@ -4,7 +4,7 @@
 
 namespace Box2D.NET
 {
-    /// A mouse joint is used to make a point on a body track a specified world point.
+    /// A mouse joint is used to make a point on body B track a point on body A.
     /// You may move local frame A to change the target point.
     /// This a soft constraint and allows the constraint to stretch without
     /// applying huge forces. This also applies rotation constraint heuristic to improve control.

--- a/src/Box2D.NET/B2MouseJoints.cs
+++ b/src/Box2D.NET/B2MouseJoints.cs
@@ -70,7 +70,6 @@ namespace Box2D.NET
         {
             B2_ASSERT(@base.type == B2JointType.b2_mouseJoint);
 
-            // chase body id to the solver set where the body lives
             int idA = @base.bodyIdA;
             int idB = @base.bodyIdB;
 
@@ -133,7 +132,7 @@ namespace Box2D.NET
             joint.linearMass = b2GetInverse22(K);
 
             float ka = iA + iB;
-            joint.axialMass = ka > 0.0f ? 1.0f / ka : 0.0f;
+            joint.angularMass = ka > 0.0f ? 1.0f / ka : 0.0f;
 
             if (context.enableWarmStarting == false)
             {
@@ -196,7 +195,7 @@ namespace Box2D.NET
                 float impulseScale = joint.angularSoftness.impulseScale;
 
                 float Cdot = wB - wA;
-                float impulse = -massScale * joint.axialMass * Cdot - impulseScale * joint.angularImpulse;
+                float impulse = -massScale * joint.angularMass * Cdot - impulseScale * joint.angularImpulse;
                 joint.angularImpulse += impulse;
 
                 wA -= iA * impulse;

--- a/src/Box2D.NET/B2PrismaticJointDef.cs
+++ b/src/Box2D.NET/B2PrismaticJointDef.cs
@@ -5,7 +5,6 @@
 namespace Box2D.NET
 {
     /// Prismatic joint definition
-    ///
     /// Body B may slide along the x-axis in local frame A. Body B cannot rotate relative to body A.
     /// The joint translation is zero when the local frame origins coincide in world space.
     /// @ingroup prismatic_joint
@@ -13,10 +12,6 @@ namespace Box2D.NET
     {
         /// Base joint definition
         public B2JointDef @base;
-        
-        /// The target translation for the joint in meters. The spring-damper will drive
-        /// to this translation.
-        public float targetTranslation;
 
         /// Enable a linear spring along the prismatic joint axis
         public bool enableSpring;
@@ -26,6 +21,10 @@ namespace Box2D.NET
 
         /// The spring damping ratio, non-dimensional
         public float dampingRatio;
+        
+        /// The target translation for the joint in meters. The spring-damper will drive
+        /// to this translation.
+        public float targetTranslation;
 
         /// Enable/disable the joint limit
         public bool enableLimit;

--- a/src/Box2D.NET/B2Profile.cs
+++ b/src/Box2D.NET/B2Profile.cs
@@ -25,6 +25,7 @@ namespace Box2D.NET
         public float storeImpulses;
         public float splitIslands;
         public float transforms;
+        public float sensorHits;
         public float jointEvents;
         public float hitEvents;
         public float refit;

--- a/src/Box2D.NET/B2RayCastInput.cs
+++ b/src/Box2D.NET/B2RayCastInput.cs
@@ -9,6 +9,7 @@ namespace Box2D.NET
      * @brief Geometry types and algorithms
      *
      * Definitions of circles, capsules, segments, and polygons. Various algorithms to compute hulls, mass properties, and so on.
+     * Functions should take the shape as the first argument to assist editor auto-complete.
      * @{
      */
     /// Low level ray cast input data

--- a/src/Box2D.NET/B2RevoluteJointDef.cs
+++ b/src/Box2D.NET/B2RevoluteJointDef.cs
@@ -5,15 +5,7 @@
 namespace Box2D.NET
 {
     /// Revolute joint definition
-    ///
-    /// This requires defining an anchor point where the bodies are joined.
-    /// The definition uses local anchor points so that the
-    /// initial configuration can violate the constraint slightly. You also need to
-    /// specify the initial relative angle for joint limits. This helps when saving
-    /// and loading a game.
-    /// The local anchor points are measured from the body's origin rather than the center of mass because:
-    /// 1. you might not know where the center of mass will be
-    /// 2. if you add/remove shapes from a body and recompute the mass, the joints will be broken
+    /// A point on body B is fixed to a point on body A. Allows relative rotation.
     /// @ingroup revolute_joint
     public struct B2RevoluteJointDef
     {

--- a/src/Box2D.NET/B2RuntimeValidator.cs
+++ b/src/Box2D.NET/B2RuntimeValidator.cs
@@ -61,6 +61,7 @@ namespace Box2D.NET
             ThrowIf(B2FixedArray8<int>.Size == B2_MAX_POLYGON_VERTICES, $"B2FixedArray8<int> and {nameof(B2_MAX_POLYGON_VERTICES)} have the same size, which is unexpected.");
             ThrowIf(B2FixedArray8<B2Vec2>.Size == B2_MAX_POLYGON_VERTICES, $"B2FixedArray8<B2Vec2> and {nameof(B2_MAX_POLYGON_VERTICES)} have the same size, which is unexpected.");
             ThrowIf(B2FixedArray4<int>.Size == B2_SIMD_WIDTH, $"B2FixedArray4<int> and {nameof(B2_SIMD_WIDTH)}have the same size, which is unexpected.");
+            ThrowIf(B2FixedArray8<float>.Size == B2_MAX_CONTINUOUS_SENSOR_HITS, $"B2FixedArray8<float> and {nameof(B2_MAX_CONTINUOUS_SENSOR_HITS)}have the same size, which is unexpected.");
         }
 
         private void CheckFixedArraySeries()

--- a/src/Box2D.NET/B2Sensor.cs
+++ b/src/Box2D.NET/B2Sensor.cs
@@ -6,6 +6,7 @@ namespace Box2D.NET
 {
     public class B2Sensor
     {
+        public B2Array<B2ShapeRef> hits;
         public B2Array<B2ShapeRef> overlaps1;
         public B2Array<B2ShapeRef> overlaps2;
         public int shapeId;

--- a/src/Box2D.NET/B2SensorBeginTouchEvent.cs
+++ b/src/Box2D.NET/B2SensorBeginTouchEvent.cs
@@ -26,7 +26,7 @@ namespace Box2D.NET
         /// The id of the sensor shape
         public B2ShapeId sensorShapeId;
 
-        /// The id of the dynamic shape that began touching the sensor shape
+        /// The id of the shape that began touching the sensor shape
         public B2ShapeId visitorShapeId;
 
         public B2SensorBeginTouchEvent(B2ShapeId sensorShapeId, B2ShapeId visitorShapeId)

--- a/src/Box2D.NET/B2SensorData.cs
+++ b/src/Box2D.NET/B2SensorData.cs
@@ -1,0 +1,22 @@
+﻿namespace Box2D.NET
+{
+    /// The contact data for two shapes. By convention the manifold normal points
+    /// from shape A to shape B.
+    /// @see b2Shape_GetContactData() and b2Body_GetContactData()
+    public struct B2SensorData
+    {
+        /// The visiting shape
+        public B2ShapeId visitorId;
+
+        /// The transform of the body of the visiting shape. This is normally
+        /// the current transform of the body. However, for a sensor hit, this is
+        /// the transform of the visiting body when it hit.
+        public B2Transform visitTransform;
+
+        public B2SensorData(B2ShapeId visitorId, B2Transform visitTransform)
+        {
+            this.visitorId = visitorId;
+            this.visitTransform = visitTransform;
+        }
+    }
+}

--- a/src/Box2D.NET/B2SensorEndTouchEvent.cs
+++ b/src/Box2D.NET/B2SensorEndTouchEvent.cs
@@ -15,7 +15,7 @@ namespace Box2D.NET
         ///	@see b2Shape_IsValid
         public B2ShapeId sensorShapeId;
 
-        /// The id of the dynamic shape that stopped touching the sensor shape
+        /// The id of the shape that stopped touching the sensor shape
         ///	@warning this shape may have been destroyed
         ///	@see b2Shape_IsValid
         public B2ShapeId visitorShapeId;

--- a/src/Box2D.NET/B2SensorEvents.cs
+++ b/src/Box2D.NET/B2SensorEvents.cs
@@ -4,7 +4,7 @@
 
 namespace Box2D.NET
 {
-    /// Sensor events are buffered in the Box2D world and are available
+    /// Sensor events are buffered in the world and are available
     /// as begin/end overlap event arrays after the time step is complete.
     /// Note: these may become invalid if bodies and/or shapes are destroyed
     public struct B2SensorEvents

--- a/src/Box2D.NET/B2SensorHit.cs
+++ b/src/Box2D.NET/B2SensorHit.cs
@@ -1,0 +1,10 @@
+﻿namespace Box2D.NET
+{
+    // Used to track shapes that hit sensors using time of impact
+    public struct B2SensorHit
+    {
+        public int sensorId;
+        public int visitorId;
+        public B2Transform visitorTransform; 
+    }
+}

--- a/src/Box2D.NET/B2ShapeDef.cs
+++ b/src/Box2D.NET/B2ShapeDef.cs
@@ -42,7 +42,7 @@ namespace Box2D.NET
         public bool enableHitEvents;
 
         /// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
-        /// and must be carefully handled due to threading. Ignored for sensors.
+        /// and must be carefully handled due to multithreading. Ignored for sensors.
         public bool enablePreSolveEvents;
 
         /// When shapes are created they will scan the environment for collision the next time step. This can significantly slow down

--- a/src/Box2D.NET/B2ShapeRef.cs
+++ b/src/Box2D.NET/B2ShapeRef.cs
@@ -6,6 +6,7 @@ namespace Box2D.NET
 {
     public struct B2ShapeRef
     {
+        public B2Transform transform;
         public int shapeId;
         public ushort generation;
     }

--- a/src/Box2D.NET/B2Shapes.cs
+++ b/src/Box2D.NET/B2Shapes.cs
@@ -183,11 +183,12 @@ namespace Box2D.NET
             if (def.isSensor)
             {
                 shape.sensorIndex = world.sensors.count;
-                B2Sensor sensor = new B2Sensor()
+                B2Sensor sensor = new B2Sensor
                 {
+                    hits = b2Array_Create<B2ShapeRef>(4),
                     overlaps1 = b2Array_Create<B2ShapeRef>(16),
                     overlaps2 = b2Array_Create<B2ShapeRef>(16),
-                    shapeId = shapeId,
+                    shapeId = shapeId
                 };
                 b2Array_Push(ref world.sensors, sensor);
             }
@@ -327,6 +328,7 @@ namespace Box2D.NET
                 }
 
                 // Destroy sensor
+                b2Array_Destroy(ref sensor.hits);
                 b2Array_Destroy(ref sensor.overlaps1);
                 b2Array_Destroy(ref sensor.overlaps2);
 
@@ -833,19 +835,19 @@ namespace Box2D.NET
             switch (shape.type)
             {
                 case B2ShapeType.b2_capsuleShape:
-                    output = b2RayCastCapsule(ref localInput, ref shape.us.capsule);
+                    output = b2RayCastCapsule(ref shape.us.capsule, ref localInput);
                     break;
                 case B2ShapeType.b2_circleShape:
-                    output = b2RayCastCircle(ref localInput, ref shape.us.circle);
+                    output = b2RayCastCircle(ref shape.us.circle, ref localInput);
                     break;
                 case B2ShapeType.b2_polygonShape:
-                    output = b2RayCastPolygon(ref localInput, ref shape.us.polygon);
+                    output = b2RayCastPolygon(ref shape.us.polygon, ref localInput);
                     break;
                 case B2ShapeType.b2_segmentShape:
-                    output = b2RayCastSegment(ref localInput, ref shape.us.segment, false);
+                    output = b2RayCastSegment(ref shape.us.segment, ref localInput, false);
                     break;
                 case B2ShapeType.b2_chainSegmentShape:
-                    output = b2RayCastSegment(ref localInput, ref shape.us.chainSegment.segment, true);
+                    output = b2RayCastSegment(ref shape.us.chainSegment.segment, ref localInput, true);
                     break;
                 default:
                     return output;
@@ -871,19 +873,19 @@ namespace Box2D.NET
             switch (shape.type)
             {
                 case B2ShapeType.b2_capsuleShape:
-                    output = b2ShapeCastCapsule(ref localInput, ref shape.us.capsule);
+                    output = b2ShapeCastCapsule(ref shape.us.capsule, ref localInput);
                     break;
                 case B2ShapeType.b2_circleShape:
-                    output = b2ShapeCastCircle(ref localInput, ref shape.us.circle);
+                    output = b2ShapeCastCircle(ref shape.us.circle, ref localInput);
                     break;
                 case B2ShapeType.b2_polygonShape:
-                    output = b2ShapeCastPolygon(ref localInput, ref shape.us.polygon);
+                    output = b2ShapeCastPolygon(ref shape.us.polygon, ref localInput);
                     break;
                 case B2ShapeType.b2_segmentShape:
-                    output = b2ShapeCastSegment(ref localInput, ref shape.us.segment);
+                    output = b2ShapeCastSegment(ref shape.us.segment, ref localInput);
                     break;
                 case B2ShapeType.b2_chainSegmentShape:
-                    output = b2ShapeCastSegment(ref localInput, ref shape.us.chainSegment.segment);
+                    output = b2ShapeCastSegment(ref shape.us.chainSegment.segment, ref localInput);
                     break;
                 default:
                     return output;
@@ -894,7 +896,7 @@ namespace Box2D.NET
             return output;
         }
 
-        public static B2PlaneResult b2CollideMover(B2Shape shape, B2Transform transform, ref B2Capsule mover)
+        public static B2PlaneResult b2CollideMover(ref B2Capsule mover, B2Shape shape, B2Transform transform)
         {
             B2Capsule localMover = new B2Capsule();
             localMover.center1 = b2InvTransformPoint(transform, mover.center1);
@@ -905,19 +907,19 @@ namespace Box2D.NET
             switch (shape.type)
             {
                 case B2ShapeType.b2_capsuleShape:
-                    result = b2CollideMoverAndCapsule(ref shape.us.capsule, ref localMover);
+                    result = b2CollideMoverAndCapsule(ref localMover, ref shape.us.capsule);
                     break;
                 case B2ShapeType.b2_circleShape:
-                    result = b2CollideMoverAndCircle(ref shape.us.circle, ref localMover);
+                    result = b2CollideMoverAndCircle(ref localMover, ref shape.us.circle);
                     break;
                 case B2ShapeType.b2_polygonShape:
-                    result = b2CollideMoverAndPolygon(ref shape.us.polygon, ref localMover);
+                    result = b2CollideMoverAndPolygon(ref localMover, ref shape.us.polygon);
                     break;
                 case B2ShapeType.b2_segmentShape:
-                    result = b2CollideMoverAndSegment(ref shape.us.segment, ref localMover);
+                    result = b2CollideMoverAndSegment(ref localMover, ref shape.us.segment);
                     break;
                 case B2ShapeType.b2_chainSegmentShape:
-                    result = b2CollideMoverAndSegment(ref shape.us.chainSegment.segment, ref localMover);
+                    result = b2CollideMoverAndSegment(ref localMover, ref shape.us.chainSegment.segment);
                     break;
                 default:
                     return result;
@@ -1025,20 +1027,20 @@ namespace Box2D.NET
             switch (shape.type)
             {
                 case B2ShapeType.b2_capsuleShape:
-                    return b2PointInCapsule(localPoint, ref shape.us.capsule);
+                    return b2PointInCapsule(ref shape.us.capsule, localPoint);
 
                 case B2ShapeType.b2_circleShape:
-                    return b2PointInCircle(localPoint, ref shape.us.circle);
+                    return b2PointInCircle(ref shape.us.circle, localPoint);
 
                 case B2ShapeType.b2_polygonShape:
-                    return b2PointInPolygon(localPoint, ref shape.us.polygon);
+                    return b2PointInPolygon(ref shape.us.polygon, localPoint);
 
                 default:
                     return false;
             }
         }
 
-// todo_erin untested
+        // todo_erin untested
         public static B2CastOutput b2Shape_RayCast(B2ShapeId shapeId, ref B2RayCastInput input)
         {
             B2World world = b2GetWorld(shapeId.world0);
@@ -1056,23 +1058,23 @@ namespace Box2D.NET
             switch (shape.type)
             {
                 case B2ShapeType.b2_capsuleShape:
-                    output = b2RayCastCapsule(ref localInput, ref shape.us.capsule);
+                    output = b2RayCastCapsule(ref shape.us.capsule, ref localInput);
                     break;
 
                 case B2ShapeType.b2_circleShape:
-                    output = b2RayCastCircle(ref localInput, ref shape.us.circle);
+                    output = b2RayCastCircle(ref shape.us.circle, ref localInput);
                     break;
 
                 case B2ShapeType.b2_segmentShape:
-                    output = b2RayCastSegment(ref localInput, ref shape.us.segment, false);
+                    output = b2RayCastSegment(ref shape.us.segment, ref localInput, false);
                     break;
 
                 case B2ShapeType.b2_polygonShape:
-                    output = b2RayCastPolygon(ref localInput, ref shape.us.polygon);
+                    output = b2RayCastPolygon(ref shape.us.polygon, ref localInput);
                     break;
 
                 case B2ShapeType.b2_chainSegmentShape:
-                    output = b2RayCastSegment(ref localInput, ref shape.us.chainSegment.segment, true);
+                    output = b2RayCastSegment(ref shape.us.chainSegment.segment, ref localInput, true);
                     break;
 
                 default:
@@ -1675,6 +1677,7 @@ namespace Box2D.NET
                     B2Shape shapeA = world.shapes.data[contact.shapeIdA];
                     B2Shape shapeB = world.shapes.data[contact.shapeIdB];
 
+                    contactData[index].contactId = new B2ContactId(contact.contactId + 1, shapeId.world0, 0, contact.generation);
                     contactData[index].shapeIdA = new B2ShapeId(shapeA.id + 1, shapeId.world0, shapeA.generation);
                     contactData[index].shapeIdB = new B2ShapeId(shapeB.id + 1, shapeId.world0, shapeB.generation);
 
@@ -1709,7 +1712,14 @@ namespace Box2D.NET
             return sensor.overlaps2.count;
         }
 
-        public static int b2Shape_GetSensorOverlaps(B2ShapeId shapeId, Span<B2ShapeId> overlaps, int capacity)
+        /// Get the overlap data for a sensor shape.
+        /// @param shapeId the id of a sensor shape
+        /// @param sensorData a user allocated array that is filled with the overlapping shapes (visitors)
+        /// @param capacity the capacity of overlappedShapes
+        /// @returns the number of elements filled in the provided array
+        /// @warning do not ignore the return value, it specifies the valid number of elements
+        /// @warning overlaps may contain destroyed shapes so use b2Shape_IsValid to confirm each overlap
+        public static int b2Shape_GetSensorData(B2ShapeId shapeId, Span<B2SensorData> sensorData, int capacity)
         {
             B2World world = b2GetWorldLocked(shapeId.world0);
             if (world == null)
@@ -1726,15 +1736,25 @@ namespace Box2D.NET
             B2Sensor sensor = b2Array_Get(ref world.sensors, shape.sensorIndex);
 
             int count = b2MinInt(sensor.overlaps2.count, capacity);
-            ref readonly B2ShapeRef[] refs = ref sensor.overlaps2.data;
+            ReadOnlySpan<B2ShapeRef> refs = sensor.overlaps2.data;
             for (int i = 0; i < count; ++i)
             {
-                overlaps[i] = new B2ShapeId(refs[i].shapeId + 1, shapeId.world0, refs[i].generation);
+                B2ShapeId visitorId = new B2ShapeId(
+                    index1: refs[i].shapeId + 1,
+                    world0: shapeId.world0,
+                    generation: refs[i].generation
+                );
+
+                sensorData[i] = new B2SensorData(
+                    visitorId: visitorId,
+                    visitTransform: refs[i].transform
+                );
             }
 
             return count;
         }
 
+        /// Get the current world AABB
         public static B2AABB b2Shape_GetAABB(B2ShapeId shapeId)
         {
             B2World world = b2GetWorld(shapeId.world0);
@@ -1747,7 +1767,8 @@ namespace Box2D.NET
             return shape.aabb;
         }
 
-        public static B2MassData b2Shape_GetMassData(B2ShapeId shapeId)
+        /// Compute the mass data for a shape
+        public static B2MassData b2Shape_ComputeMassData(B2ShapeId shapeId)
         {
             B2World world = b2GetWorld(shapeId.world0);
             if (world == null)

--- a/src/Box2D.NET/B2TOIInput.cs
+++ b/src/Box2D.NET/B2TOIInput.cs
@@ -4,7 +4,7 @@
 
 namespace Box2D.NET
 {
-    /// Input parameters for b2TimeOfImpact
+    /// Time of impact input
     public struct B2TOIInput
     {
         public B2ShapeProxy proxyA; // The proxy for shape A

--- a/src/Box2D.NET/B2TOIOutput.cs
+++ b/src/Box2D.NET/B2TOIOutput.cs
@@ -4,10 +4,19 @@
 
 namespace Box2D.NET
 {
-    /// Output parameters for b2TimeOfImpact.
+    /// Time of impact output
     public struct B2TOIOutput
     {
-        public B2TOIState state; // The type of result
-        public float fraction; // The sweep time of the collision
+        /// The type of result
+        public B2TOIState state;
+
+        /// The hit point
+        public B2Vec2 point;
+
+        /// The hit normal
+        public B2Vec2 normal;
+
+        /// The sweep time of the collision 
+        public float fraction;
     }
 }

--- a/src/Box2D.NET/B2TaskContext.cs
+++ b/src/Box2D.NET/B2TaskContext.cs
@@ -7,6 +7,9 @@ namespace Box2D.NET
     // Per thread task storage
     public class B2TaskContext
     {
+        // Collect per thread sensor continuous hit events.
+        public B2Array<B2SensorHit> sensorHits;
+        
         // These bits align with the contact id capacity and signal a change in contact status
         public B2BitSet contactStateBitSet;
 

--- a/src/Box2D.NET/B2TracyCZone.cs
+++ b/src/Box2D.NET/B2TracyCZone.cs
@@ -44,5 +44,6 @@ namespace Box2D.NET
         collide,
         contact_state,
         world_step,
+        sensor_hits,
     }
 }

--- a/src/Box2D.NET/B2Types.cs
+++ b/src/Box2D.NET/B2Types.cs
@@ -21,7 +21,7 @@ namespace Box2D.NET
             def.gravity.Y = -10.0f;
             def.hitEventThreshold = 1.0f * b2_lengthUnitsPerMeter;
             def.restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
-            def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
+            def.contactSpeed = 3.0f * b2_lengthUnitsPerMeter;
             def.contactHertz = 30.0f;
             def.contactDampingRatio = 10.0f;
             

--- a/src/Box2D.NET/B2WeldJointDef.cs
+++ b/src/Box2D.NET/B2WeldJointDef.cs
@@ -5,11 +5,10 @@
 namespace Box2D.NET
 {
     /// Weld joint definition
-    ///
-    /// A weld joint connect to bodies together rigidly. This constraint provides springs to mimic
+    /// Connects two bodies together rigidly. This constraint provides springs to mimic
     /// soft-body simulation.
     /// @note The approximate solver in Box2D cannot hold many bodies together rigidly
-    /// @ingroup weld_joint
+    /// @ingroup weld_join
     public struct B2WeldJointDef
     {
         /// Base joint definition

--- a/src/Box2D.NET/B2WheelJointDef.cs
+++ b/src/Box2D.NET/B2WheelJointDef.cs
@@ -5,7 +5,6 @@
 namespace Box2D.NET
 {
     /// Wheel joint definition
-    ///
     /// Body B is a wheel that may rotate freely and slide along the local x-axis in frame A.
     /// The joint translation is zero when the local frame origins coincide in world space.
     /// @ingroup wheel_joint

--- a/src/Box2D.NET/B2World.cs
+++ b/src/Box2D.NET/B2World.cs
@@ -70,7 +70,6 @@ namespace Box2D.NET
         public B2Array<B2BodyMoveEvent> bodyMoveEvents;
         public B2Array<B2SensorBeginTouchEvent> sensorBeginEvents;
         public B2Array<B2ContactBeginTouchEvent> contactBeginEvents;
-        public B2Array<B2JointEvent> jointEvents;
 
         // End events are double buffered so that the user doesn't need to flush events
         public B2Array<B2SensorEndTouchEvent>[] sensorEndEvents = new B2Array<B2SensorEndTouchEvent>[2];
@@ -78,6 +77,7 @@ namespace Box2D.NET
         public int endEventArrayIndex;
 
         public B2Array<B2ContactHitEvent> contactHitEvents;
+        public B2Array<B2JointEvent> jointEvents;
 
         // Used to track debug draw
         public B2BitSet debugBodySet;
@@ -101,7 +101,6 @@ namespace Box2D.NET
         public float hitEventThreshold;
         public float restitutionThreshold;
         public float maxLinearSpeed;
-        public float maxContactPushSpeed;
         public float contactSpeed;
         public float contactHertz;
         public float contactDampingRatio;
@@ -184,7 +183,6 @@ namespace Box2D.NET
             bodyMoveEvents = new B2Array<B2BodyMoveEvent>();
             sensorBeginEvents = new B2Array<B2SensorBeginTouchEvent>();
             contactBeginEvents = new B2Array<B2ContactBeginTouchEvent>();
-            jointEvents = new B2Array<B2JointEvent>();
 
             sensorEndEvents[0] = new B2Array<B2SensorEndTouchEvent>();
             sensorEndEvents[1] = new B2Array<B2SensorEndTouchEvent>();
@@ -193,6 +191,7 @@ namespace Box2D.NET
             endEventArrayIndex = 0;
 
             contactHitEvents = new B2Array<B2ContactHitEvent>();
+            jointEvents = new B2Array<B2JointEvent>();
 
             // debugBodySet = null;
             // debugJointSet = null;
@@ -206,7 +205,6 @@ namespace Box2D.NET
             hitEventThreshold = 0.0f;
             restitutionThreshold = 0.0f;
             maxLinearSpeed = 0.0f;
-            maxContactPushSpeed = 0.0f;
             contactSpeed = 0.0f;
             contactHertz = 0.0f;
             contactDampingRatio = 0.0f;

--- a/src/Box2D.NET/B2WorldDef.cs
+++ b/src/Box2D.NET/B2WorldDef.cs
@@ -29,7 +29,7 @@ namespace Box2D.NET
         /// This parameter controls how fast overlap is resolved and usually has units of meters per second. This only
         /// puts a cap on the resolution speed. The resolution speed is increased by increasing the hertz and/or
         /// decreasing the damping ratio.
-        public float maxContactPushSpeed;
+        public float contactSpeed;
 
         /// Maximum linear speed. Usually meters per second.
         public float maximumLinearSpeed;

--- a/test/Box2D.NET.Test/B2DeterminismTest.cs
+++ b/test/Box2D.NET.Test/B2DeterminismTest.cs
@@ -131,8 +131,8 @@ public class b2TaskTester : IDisposable
 
 public class B2DeterminismTest
 {
-    private const int EXPECTED_SLEEP_STEP = 342;
-    private const uint EXPECTED_HASH = 0xd8d6b53a;
+    private const int EXPECTED_SLEEP_STEP = 244;
+    private const uint EXPECTED_HASH = 0xfcb96059;
 
     private const int e_maxTasks = 128;
 

--- a/test/Box2D.NET.Test/B2ShapeTest.cs
+++ b/test/Box2D.NET.Test/B2ShapeTest.cs
@@ -113,17 +113,17 @@ public class B2ShapeTest
 
         {
             bool hit;
-            hit = b2PointInCircle(p1, ref circle);
+            hit = b2PointInCircle(ref circle, p1);
             Assert.That(hit, Is.EqualTo(true));
-            hit = b2PointInCircle(p2, ref circle);
+            hit = b2PointInCircle(ref circle, p2);
             Assert.That(hit, Is.EqualTo(false));
         }
 
         {
             bool hit;
-            hit = b2PointInPolygon(p1, ref box);
+            hit = b2PointInPolygon(ref box, p1);
             Assert.That(hit, Is.EqualTo(true));
-            hit = b2PointInPolygon(p2, ref box);
+            hit = b2PointInPolygon(ref box, p2);
             Assert.That(hit, Is.EqualTo(false));
         }
     }
@@ -134,7 +134,7 @@ public class B2ShapeTest
         B2RayCastInput input = new B2RayCastInput(new B2Vec2(-4.0f, 0.0f), new B2Vec2(8.0f, 0.0f), 1.0f);
 
         {
-            B2CastOutput output = b2RayCastCircle(ref input, ref circle);
+            B2CastOutput output = b2RayCastCircle(ref circle, ref input);
             Assert.That(output.hit);
             Assert.That(output.normal.X + 1.0f, Is.LessThan(FLT_EPSILON));
             Assert.That(output.normal.Y, Is.LessThan(FLT_EPSILON));
@@ -142,7 +142,7 @@ public class B2ShapeTest
         }
 
         {
-            B2CastOutput output = b2RayCastPolygon(ref input, ref box);
+            B2CastOutput output = b2RayCastPolygon(ref box, ref input);
             Assert.That(output.hit);
             Assert.That(output.normal.X + 1.0f, Is.LessThan(FLT_EPSILON));
             Assert.That(output.normal.Y, Is.LessThan(FLT_EPSILON));
@@ -150,7 +150,7 @@ public class B2ShapeTest
         }
 
         {
-            B2CastOutput output = b2RayCastSegment(ref input, ref segment, true);
+            B2CastOutput output = b2RayCastSegment(ref segment, ref input, true);
             Assert.That(output.hit);
             Assert.That(output.normal.X + 1.0f, Is.LessThan(FLT_EPSILON));
             Assert.That(output.normal.Y, Is.LessThan(FLT_EPSILON));

--- a/test/Box2D.NET.Test/B2WorldTest.cs
+++ b/test/Box2D.NET.Test/B2WorldTest.cs
@@ -255,11 +255,12 @@ public class B2WorldTest
         return true;
     }
 
-    public static bool PreSolveStatic(B2ShapeId shapeIdA, B2ShapeId shapeIdB, ref B2Manifold manifold, object context)
+    public static bool PreSolveStatic(B2ShapeId shapeIdA, B2ShapeId shapeIdB, B2Vec2 point, B2Vec2 normal, object context)
     {
         B2_UNUSED(shapeIdA);
         B2_UNUSED(shapeIdB);
-        B2_UNUSED(manifold);
+        B2_UNUSED(point);
+        B2_UNUSED(normal);
         Assert.That(context, Is.EqualTo(null));
         return false;
     }


### PR DESCRIPTION
[upstream] https://github.com/erincatto/box2d/pull/945

Sensor hits for shapes that move fast over sensors. `b2SensorData` that has the visitor shape id and the captured visitor body transform.

Bug fix: sensors were not using the custom filter. Time of impact now returns the point and normal.

`b2PreSolveFcn` now returns a contact point and normal instead of the manifold. This change was made to support more efficient continuous collision and for consistency. Pre-solve is called in continuous and discrete collision, but continuous collision no longer uses manifolds. Contact push speed is now independent of contact hertz and damping ratio.

Bumped version to 3.2.0 (work in progress).

Renamed: `b2Shape_GetMassData` to `b2Shape_ComputeMassData` Removed: `b2Contact_GetManifold`  and `b2Contact_GetShapeIds` Added: `b2Contact_GetData`

Changed function order on some collision functions to assist editor auto-complete

`id.h` is now stand-alone

Renamed: `b2WorldDef::maxContactPushSpeed` to `contactSpeed` Added: `b2BodyDef::enableSensorHits`

Added: `b2JointDef::constraintHertz` and `b2JointDef::constraintDampingRatio` Renamed: `b2JointDef::drawSize` to 

`b2JointDef::drawScale` Removed: `b2ContactBeginTouchEvent::manifold`

Added: `b2ContactData::contactId`

Modified: `b2PreSolveFcn` receives a point and normal instead of a manifold

5st