### PR TITLE
[upstream] Motion locks (box2d #950)

### DIFF
--- a/src/Box2D.NET.Samples/Draw.cs
+++ b/src/Box2D.NET.Samples/Draw.cs
@@ -27,7 +27,6 @@ public class Draw
     private GLSolidPolygons m_solidPolygons;
     public B2DebugDraw m_debugDraw;
 
-    public ImFontPtr m_smallFont;
     public ImFontPtr m_regularFont;
     public ImFontPtr m_mediumFont;
     public ImFontPtr m_largeFont;
@@ -76,7 +75,6 @@ public class Draw
 
         m_debugDraw.context = this;
 
-        m_smallFont = default;
         m_mediumFont = default;
         m_largeFont = default;
         m_regularFont = default;

--- a/src/Box2D.NET.Samples/SampleApp.cs
+++ b/src/Box2D.NET.Samples/SampleApp.cs
@@ -41,7 +41,6 @@ public class SampleApp
     private SampleContext _context;
     private bool s_rightMouseDown = false;
     private B2Vec2 s_clickPointWS = b2Vec2_zero;
-    private float s_fontScale = 1.0f;
     private float s_framebufferScale = 1.0f;
     private float _frameTime = 0.0f;
 
@@ -100,7 +99,9 @@ public class SampleApp
                 }
                 else
                 {
-                    _context.glfw.GetMonitorContentScale(primaryMonitor, out s_fontScale, out s_fontScale);
+                    float uiScale = 1.0f;
+                    _context.glfw.GetMonitorContentScale(primaryMonitor, out uiScale, out uiScale);
+                    _context.settings.uiScale = uiScale;
                 }
             }
         }
@@ -109,7 +110,7 @@ public class SampleApp
         bool fullscreen = false;
         if (fullscreen)
         {
-            options.Size = new Vector2D<int>((int)(1920), (int)(1080));
+            options.Size = new Vector2D<int>(1920, 1080);
             //_context.g_mainWindow = _context.g_glfw.CreateWindow((int)(1920 ), (int)(1080 ), buffer, _ctx.g_glfw.GetPrimaryMonitor(), null);
         }
         else
@@ -194,15 +195,6 @@ public class SampleApp
             {
                 Logger.Information("Failed to open GLFW _ctx.g_mainWindow.");
                 return;
-            }
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                //_context.glfw.GetWindowContentScale(_context.window, out s_framebufferScale, out s_framebufferScale);
-            }
-            else
-            {
-                //_context.glfw.GetWindowContentScale(_context.window, out s_fontScale, out s_fontScale);
             }
 
             _context.glfw.MakeContextCurrent(_context.window);
@@ -302,7 +294,7 @@ public class SampleApp
             // #todo restore all drawing settings that may have been overridden by a sample
             _context.settings.subStepCount = 4;
             _context.settings.drawJoints = true;
-            _context.settings.useCameraBounds = false;
+            _context.settings.useCameraBounds = true;
 
             s_sample?.Dispose();
             s_sample = null;
@@ -485,25 +477,30 @@ public class SampleApp
             return;
         }
 
-
         // for windows : Microsoft Visual C++ Redistributable Package
         // link - https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
         var imGuiFontConfig = new ImGuiFontConfig(fontPath, 15, null);
         _imgui = new ImGuiController(_context.gl, _window, _input, imGuiFontConfig);
 
-        //ImGui.GetStyle().ScaleAllSizes(2);
-        //imGuiIo.FontGlobalScale = 2.0f;
+        ImGui.GetFontSize();
+        ImGui.GetStyle().ScaleAllSizes(_context.settings.uiScale);
 
-        // var imGuiIo = ImGui.GetIO();
-        // var s = new ImFontConfig();
-        // ImFontConfigPtr fontConfig = new ImFontConfigPtr(&s);
-        // fontConfig.RasterizerMultiply = s_fontScale * s_framebufferScale;
-        // _context.draw.m_smallFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 14.0f * s_fontScale, fontConfig, IntPtr.Zero);
-        // _context.draw.m_regularFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 18.0f * s_fontScale, fontConfig, IntPtr.Zero);
-        // _context.draw.m_mediumFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 40.0f * s_fontScale, fontConfig, IntPtr.Zero);
-        // _context.draw.m_largeFont = imGuiIo.Fonts.AddFontFromFileTTF(fontPath, 64.0f * s_fontScale, fontConfig, IntPtr.Zero);
+        unsafe
+        {
+            // ImFontConfigPtr fontConfig = new ImFontConfigPtr(ImGuiNative.ImFontConfig_ImFontConfig());
+            // fontConfig.RasterizerMultiply = _context.settings.uiScale * s_framebufferScale;
+            //
+            // float regularSize = MathF.Floor(13.0f * _context.settings.uiScale);
+            // float mediumSize = MathF.Floor(40.0f * _context.settings.uiScale);
+            // float largeSize = MathF.Floor(64.0f * _context.settings.uiScale);
+            //
+            // var io = ImGui.GetIO();
+            //_context.draw.m_regularFont = io.Fonts.AddFontFromFileTTF(fontPath, regularSize, fontConfig);
+            // _context.draw.m_mediumFont = io.Fonts.AddFontFromFileTTF(fontPath, mediumSize, fontConfig);
+            // _context.draw.m_largeFont = io.Fonts.AddFontFromFileTTF(fontPath, largeSize, fontConfig);
 
-        //imGuiIo.FontDefault = _context.draw.m_smallFont;
+            //io.FontDefault = _context.draw.m_regularFont;
+        }
     }
 
     public void DestroyUI()
@@ -726,11 +723,12 @@ public class SampleApp
     {
         int maxWorkers = (int)(Environment.ProcessorCount * 1.5f);
 
-        float menuWidth = 180.0f;
+        float fontSize = ImGui.GetFontSize();
+        float menuWidth = 13.0f * fontSize;
         if (_context.draw.m_showUI)
         {
-            ImGui.SetNextWindowPos(new Vector2(_context.camera.m_width - menuWidth - 10.0f, 10.0f));
-            ImGui.SetNextWindowSize(new Vector2(menuWidth, _context.camera.m_height - 20.0f));
+            ImGui.SetNextWindowPos(new Vector2(_context.camera.m_width - menuWidth - 0.5f * fontSize, 0.5f * fontSize));
+            ImGui.SetNextWindowSize(new Vector2(menuWidth, _context.camera.m_height - fontSize));
 
             ImGui.Begin("Tools", ref _context.draw.m_showUI, ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse);
 

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkBarrel.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkBarrel.cs
@@ -21,7 +21,7 @@ namespace Box2D.NET.Samples.Samples.Benchmarks;
 public class BenchmarkBarrel : Sample
 {
     private static readonly int SampleBenchmarkBarrel = SampleFactory.Shared.RegisterSample("Benchmark", "Barrel", Create);
-    
+
     public enum ShapeType
     {
         e_circleShape = 0,
@@ -309,10 +309,12 @@ public class BenchmarkBarrel : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
-        float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(220.0f, height));
+
+        float fontSize = ImGui.GetFontSize();
+        float height = 6.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(15.0f * fontSize, height));
+
         ImGui.Begin("Benchmark: Barrel", ImGuiWindowFlags.NoResize);
 
         bool changed = false;
@@ -332,7 +334,7 @@ public class BenchmarkBarrel : Sample
         {
             changed = true;
         }
-            
+
         m_shapeType = (ShapeType)shapeType;
 
         if (ImGui.Button("Reset Scene"))

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkCast.cs
@@ -243,7 +243,7 @@ public class BenchmarkCast : Sample
 
             for (int i = 0; i < sampleCount; ++i)
             {
-                B2ShapeProxy proxy = b2MakeProxy( m_origins[i], 1, m_radius );
+                B2ShapeProxy proxy = b2MakeProxy(m_origins[i], 1, m_radius);
 
                 B2Vec2 translation = m_translations[i];
 
@@ -324,13 +324,14 @@ public class BenchmarkCast : Sample
     {
         base.UpdateGui();
 
-        float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(200.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 17.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(13.0f * fontSize, height));
 
         ImGui.Begin("Cast", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 
-        ImGui.PushItemWidth(100.0f);
+        ImGui.PushItemWidth(7.5f * fontSize);
 
         bool changed = false;
 
@@ -400,19 +401,18 @@ public class BenchmarkCast : Sample
         base.Draw(settings);
 
         DrawTextLine($"build time ms = {m_buildTime:g}");
-        
+
 
         DrawTextLine($"hit count = {hitCount}, node visits = {nodeVisits}, leaf visits = {leafVisits}");
-        
+
 
         DrawTextLine($"total ms = {ms:F3}");
-        
+
 
         DrawTextLine($"min total ms = {m_minTime:F3}");
-        
+
 
         float aveRayCost = 1000.0f * m_minTime / (float)sampleCount;
         DrawTextLine($"average us = {aveRayCost:F2}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyTumblers.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkManyTumblers.cs
@@ -18,7 +18,7 @@ namespace Box2D.NET.Samples.Samples.Benchmarks;
 public class BenchmarkManyTumblers : Sample
 {
     private static readonly int SampleBenchmarkManyTumblers = SampleFactory.Shared.RegisterSample("Benchmark", "Many Tumblers", Create);
-    
+
     private B2BodyId m_groundId;
 
     private int m_rowCount;
@@ -141,12 +141,13 @@ public class BenchmarkManyTumblers : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
-        float height = 110.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(200.0f, height));
+
+        float fontSize = ImGui.GetFontSize();
+        float height = 8.5f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(15.5f * fontSize, height));
         ImGui.Begin("Benchmark: Many Tumblers", ImGuiWindowFlags.NoResize);
-        ImGui.PushItemWidth(100.0f);
+        ImGui.PushItemWidth(8.0f * fontSize);
 
         bool changed = false;
         changed = changed || ImGui.SliderInt("Row Count", ref m_rowCount, 1, 32);

--- a/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Benchmarks/BenchmarkShapeDistance.cs
@@ -100,9 +100,10 @@ public class BenchmarkShapeDistance : Sample
 
     public override void UpdateGui()
     {
-        float height = 80.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(220.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 5.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(17.0f * fontSize, height));
         ImGui.Begin("Benchmark: Shape Distance", ImGuiWindowFlags.NoResize);
 
         ImGui.SliderInt("draw index", ref m_drawIndex, 0, m_count - 1);

--- a/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
@@ -201,10 +201,10 @@ public class BodyType : Sample
     {
         base.UpdateGui();
 
-
-        float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(180.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 11.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(9.0f * fontSize, height));
         ImGui.Begin("Body Type", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 
         if (ImGui.RadioButton("Static", m_type == B2BodyType.b2_staticBody))

--- a/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Sleep.cs
@@ -174,8 +174,10 @@ public class Sleep : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
+
+        float fontSize = ImGui.GetFontSize();
         float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
         ImGui.Begin("Sleep", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/Weeble.cs
@@ -17,7 +17,7 @@ namespace Box2D.NET.Samples.Samples.Bodies;
 public class Weeble : Sample
 {
     private static readonly int SampleWeeble = SampleFactory.Shared.RegisterSample("Bodies", "Weeble", Create);
-    
+
     private B2BodyId m_weebleId;
     private B2Vec2 m_explosionPosition;
     private float m_explosionRadius;
@@ -93,9 +93,10 @@ public class Weeble : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 120.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
         ImGui.Begin("Weeble", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
         if (ImGui.Button("Teleport"))

--- a/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
+++ b/src/Box2D.NET.Samples/Samples/Characters/Mover.cs
@@ -22,7 +22,7 @@ namespace Box2D.NET.Samples.Samples.Characters;
 
 public class Mover : Sample
 {
-    private static int SampleMover = SampleFactory.Shared.RegisterSample("Character", "Mover", Create);
+    private static readonly int SampleMover = SampleFactory.Shared.RegisterSample("Character", "Mover", Create);
 
     public class ShapeUserData
     {
@@ -460,8 +460,9 @@ public class Mover : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 350.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(340.0f, height));
 
         ImGui.Begin("Mover", 0);

--- a/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/CastWorld.cs
@@ -290,8 +290,9 @@ public class CastWorld : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Ray-cast World", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/DynamicTree.cs
@@ -191,8 +191,9 @@ public class DynamicTree : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Dynamic Tree", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -448,7 +449,6 @@ public class DynamicTree : Sample
             m_draw.DrawPoint(m_endPoint, 5.0f, B2HexColor.b2_colorRed);
 
             DrawTextLine($"node visits = {result.nodeVisits}, leaf visits = {result.leafVisits}");
-            
         }
 
         switch ((UpdateType)m_updateType)
@@ -456,21 +456,18 @@ public class DynamicTree : Sample
             case UpdateType.Update_Incremental:
             {
                 DrawTextLine($"incremental : {_ms:F3} ms");
-                
             }
                 break;
 
             case UpdateType.Update_FullRebuild:
             {
                 DrawTextLine($"full build {_boxCount} : {_ms:F3} ms");
-                
             }
                 break;
 
             case UpdateType.Update_PartialRebuild:
             {
                 DrawTextLine($"partial rebuild {_boxCount} : {_ms:F3} ms");
-                
             }
                 break;
 
@@ -484,6 +481,5 @@ public class DynamicTree : Sample
 
         int hmin = (int)(MathF.Ceiling(MathF.Log((float)m_proxyCount) / MathF.Log(2.0f) - 1.0f));
         DrawTextLine($"proxies = {m_proxyCount}, height = {height}, hmin = {hmin}, area ratio = {areaRatio:F1}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/Manifold.cs
@@ -89,13 +89,14 @@ public class Manifold : Sample
     {
         base.UpdateGui();
 
-        float height = 320.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(340.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 24.0f * fontSize;
+        ImGui.SetNextWindowPos( new Vector2( 0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize ), ImGuiCond.Once );
+        ImGui.SetNextWindowSize( new Vector2( 20.0f * fontSize, height ) );
 
-        ImGui.Begin("Manifold", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
+        ImGui.Begin( "Manifold", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize );
 
-        ImGui.PushItemWidth(280.0f);
+        ImGui.PushItemWidth( 14.0f * fontSize );
 
         ImGui.SliderFloat("x offset", ref m_transform.p.X, -2.0f, 2.0f, "%.2f");
         ImGui.SliderFloat("y offset", ref m_transform.p.Y, -2.0f, 2.0f, "%.2f");

--- a/src/Box2D.NET.Samples/Samples/Collisions/OverlapWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/OverlapWorld.cs
@@ -269,8 +269,9 @@ public class OverlapWorld : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 330.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Overlap World", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -391,9 +392,9 @@ public class OverlapWorld : Sample
         base.Draw(settings);
 
         DrawTextLine("left mouse button: drag query shape");
-        
+
         DrawTextLine("left mouse button + shift: rotate query shape");
-        
+
 
         if (B2_IS_NON_NULL(m_bodyIds[m_ignoreIndex]))
         {

--- a/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/RayCast.cs
@@ -83,8 +83,9 @@ public class RayCast : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Ray-cast", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeCast.cs
@@ -289,8 +289,9 @@ public class ShapeCast : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 300.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Distance", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/ShapeDistance.cs
@@ -18,7 +18,7 @@ namespace Box2D.NET.Samples.Samples.Collisions;
 public class ShapeDistance : Sample
 {
     private static readonly int SampleShapeDistance = SampleFactory.Shared.RegisterSample("Collision", "Shape Distance", Create);
-    
+
     public const int m_simplexCapacity = 20;
 
     B2Polygon m_box;
@@ -90,7 +90,7 @@ public class ShapeDistance : Sample
             B2Vec2[] points = new B2Vec2[3] { new B2Vec2(-0.5f, 0.0f), new B2Vec2(0.5f, 0.0f), new B2Vec2(0.0f, 1.0f) };
             B2Hull hull = b2ComputeHull(points, 3);
             m_triangle = b2MakePolygon(ref hull, 0.0f);
-            
+
             // m_triangle = b2MakeSquare( 0.4f );
         }
 
@@ -140,10 +140,11 @@ public class ShapeDistance : Sample
                 break;
 
             case ShapeType.e_triangle:
-                for ( int i = 0; i < m_triangle.count; ++i )
+                for (int i = 0; i < m_triangle.count; ++i)
                 {
                     proxy.points[i] = m_triangle.vertices[i];
                 }
+
                 proxy.count = m_triangle.count;
                 break;
 
@@ -215,8 +216,9 @@ public class ShapeDistance : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 310.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Distance", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -309,7 +311,7 @@ public class ShapeDistance : Sample
     {
         if (m_dragging)
         {
-            m_transform.p = m_basePosition + 0.5f * ( p - m_startPoint );
+            m_transform.p = m_basePosition + 0.5f * (p - m_startPoint);
         }
         else if (m_rotating)
         {
@@ -421,8 +423,8 @@ public class ShapeDistance : Sample
             m_draw.DrawLine(_outputPointA, _outputPointB, B2HexColor.b2_colorDimGray);
             m_draw.DrawPoint(_outputPointA, 10.0f, B2HexColor.b2_colorWhite);
             m_draw.DrawPoint(_outputPointB, 10.0f, B2HexColor.b2_colorWhite);
-            
-            m_draw.DrawLine( _outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow );
+
+            m_draw.DrawLine(_outputPointA, _outputPointA + 0.5f * _outputNormal, B2HexColor.b2_colorYellow);
         }
 
         if (m_showIndices)
@@ -441,11 +443,11 @@ public class ShapeDistance : Sample
         }
 
         DrawTextLine("mouse button 1: drag");
-        
+
         DrawTextLine("mouse button 1 + shift: rotate");
-        
+
         DrawTextLine($"distance = {_outputDistance:F2}, iterations = {_outputIterations}");
-        
+
 
         if (m_cache.count == 1)
         {
@@ -459,7 +461,5 @@ public class ShapeDistance : Sample
         {
             DrawTextLine($"cache = {m_cache.indexA[0]}, {m_cache.indexA[1]}, {m_cache.indexA[2]}, {m_cache.indexB[0]}, {m_cache.indexB[1]}, {m_cache.indexB[2]}");
         }
-
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
+++ b/src/Box2D.NET.Samples/Samples/Collisions/SmoothManifold.cs
@@ -135,9 +135,10 @@ public class SmoothManifold : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 290.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Smooth Manifold", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -259,7 +260,7 @@ public class SmoothManifold : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         B2HexColor color1 = B2HexColor.b2_colorYellow;
         B2HexColor color2 = B2HexColor.b2_colorMagenta;
 

--- a/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
@@ -127,8 +127,9 @@ public class BounceHouse : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Bounce House", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/ChainDrop.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/ChainDrop.cs
@@ -15,7 +15,7 @@ namespace Box2D.NET.Samples.Samples.Continuous;
 public class ChainDrop : Sample
 {
     private static readonly int SampleChainDrop = SampleFactory.Shared.RegisterSample("Continuous", "Chain Drop", Create);
-    
+
     private B2BodyId m_bodyId;
     private B2ShapeId m_shapeId;
     private float m_yOffset;
@@ -69,7 +69,7 @@ public class ChainDrop : Sample
         bodyDef.linearVelocity = new B2Vec2(0.0f, m_speed);
         bodyDef.position = new B2Vec2(0.0f, 10.0f + m_yOffset);
         bodyDef.rotation = b2MakeRot(0.5f * B2_PI);
-        bodyDef.fixedRotation = true;
+        bodyDef.motionLocks.angularZ = true;
         m_bodyId = b2CreateBody(m_worldId, ref bodyDef);
 
         B2ShapeDef shapeDef = b2DefaultShapeDef();
@@ -88,9 +88,10 @@ public class ChainDrop : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Chain Drop", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/GhostBumps.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/GhostBumps.cs
@@ -19,7 +19,7 @@ namespace Box2D.NET.Samples.Samples.Continuous;
 public class GhostBumps : Sample
 {
     private static readonly int SampleGhostCollision = SampleFactory.Shared.RegisterSample("Continuous", "Ghost Bumps", Create);
-    
+
     private enum ShapeType
     {
         e_circleShape = 0,
@@ -270,9 +270,10 @@ public class GhostBumps : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Ghost Bumps", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Continuous/PixelImperfect.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/PixelImperfect.cs
@@ -58,7 +58,7 @@ public class PixelImperfect : Sample
             //ballShapeDef.restitution = 1.f;
             b2CreatePolygonShape(m_ballId, ref ballShapeDef, ref ballShape);
             b2Body_SetLinearVelocity(m_ballId, new B2Vec2(0.0f, -5.0f));
-            b2Body_SetFixedRotation(m_ballId, true);
+            b2Body_SetMotionLocks(m_ballId, new B2MotionLocks(false, false, true));
         }
     }
 
@@ -73,10 +73,9 @@ public class PixelImperfect : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         B2Vec2 p = b2Body_GetPosition(m_ballId);
         B2Vec2 v = b2Body_GetLinearVelocity(m_ballId);
         DrawTextLine($"p.x = {p.X:F9}, v.y = {v.Y:F9}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Continuous/RestitutionThreshold.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/RestitutionThreshold.cs
@@ -63,7 +63,7 @@ public class RestitutionThreshold : Sample
             b2CreateCircleShape(m_ballId, ref ballShapeDef, ref ballShape);
 
             b2Body_SetLinearVelocity(m_ballId, new B2Vec2(0.0f, -2.9f)); // Initial velocity
-            b2Body_SetFixedRotation(m_ballId, true); // Do not rotate a ball
+            b2Body_SetMotionLocks(m_ballId, new B2MotionLocks(false, false, true)); // Do not rotate a ball
         }
     }
 
@@ -82,6 +82,5 @@ public class RestitutionThreshold : Sample
         B2Vec2 p = b2Body_GetPosition(m_ballId);
         B2Vec2 v = b2Body_GetLinearVelocity(m_ballId);
         DrawTextLine($"p.x = {p.X:F9}, v.y = {v.Y:F9}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Continuous/SkinnyBox.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/SkinnyBox.cs
@@ -17,7 +17,7 @@ namespace Box2D.NET.Samples.Samples.Continuous;
 public class SkinnyBox : Sample
 {
     private static readonly int SampleSkinnyBox = SampleFactory.Shared.RegisterSample("Continuous", "Skinny Box", Create);
-    
+
     private B2BodyId m_bodyId, m_bulletId;
     private float m_angularVelocity;
     private float m_x;
@@ -114,9 +114,10 @@ public class SkinnyBox : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 110.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Skinny Box", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/BodyMove.cs
@@ -173,8 +173,9 @@ public class BodyMove : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Body Move", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -201,6 +202,5 @@ public class BodyMove : Sample
         m_draw.DrawCircle(m_explosionPosition, m_explosionRadius, B2HexColor.b2_colorAzure);
 
         DrawTextLine($"sleep count: {m_sleepCount}");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/ContactEvent.cs
@@ -147,8 +147,9 @@ public class ContactEvent : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Contact Event", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
@@ -434,6 +435,5 @@ public class ContactEvent : Sample
         base.Draw(settings);
 
         DrawTextLine("move using WASD");
-        
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/FootSensor.cs
@@ -72,7 +72,7 @@ public class FootSensor : Sample
         {
             B2BodyDef bodyDef = b2DefaultBodyDef();
             bodyDef.type = B2BodyType.b2_dynamicBody;
-            bodyDef.fixedRotation = true;
+            bodyDef.motionLocks.angularZ = true;
             bodyDef.position = new B2Vec2(0.0f, 1.0f);
             m_playerId = b2CreateBody(m_worldId, ref bodyDef);
             B2ShapeDef shapeDef = b2DefaultShapeDef();

--- a/src/Box2D.NET.Samples/Samples/Events/Platform.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/Platform.cs
@@ -97,7 +97,7 @@ public class Platform : Sample
         {
             B2BodyDef bodyDef = b2DefaultBodyDef();
             bodyDef.type = B2BodyType.b2_dynamicBody;
-            bodyDef.fixedRotation = true;
+            bodyDef.motionLocks.angularZ = true;
             bodyDef.linearDamping = 0.5f;
             bodyDef.position = new B2Vec2(0.0f, 1.0f);
             m_playerId = b2CreateBody(m_worldId, ref bodyDef);
@@ -158,8 +158,9 @@ public class Platform : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("One-Sided Platform", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/SensorBookend.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorBookend.cs
@@ -122,9 +122,10 @@ public class SensorBookend : Sample
 
     public override void UpdateGui()
     {
-        float height = 260.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(200.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 19.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(12.0f * fontSize, height));
 
         ImGui.Begin("Sensor Bookend", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorFunnel.cs
@@ -260,8 +260,9 @@ public class SensorFunnel : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 90.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(140.0f, height));
 
         ImGui.Begin("Sensor Event", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Events/SensorHits.cs
+++ b/src/Box2D.NET.Samples/Samples/Events/SensorHits.cs
@@ -174,8 +174,9 @@ public class SensorHits : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 120.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(120.0f, height));
 
         ImGui.Begin("Sensor Hit", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BallAndChain.cs
@@ -111,8 +111,9 @@ public class BallAndChain : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Ball and Chain", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/BreakableJoint.cs
@@ -203,8 +203,9 @@ public class BreakableJoint : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Breakable Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Bridge.cs
@@ -142,8 +142,9 @@ public class Bridge : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(320.0f, height));
 
         ImGui.Begin("Bridge", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Cantilever.cs
@@ -104,12 +104,13 @@ public class Cantilever : Sample
     {
         base.UpdateGui();
 
-        float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(240.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 14.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(19.0f * fontSize, height));
 
         ImGui.Begin("Cantilever", ImGuiWindowFlags.NoResize);
-        ImGui.PushItemWidth(100.0f);
+        ImGui.PushItemWidth(8.0f * fontSize);
 
         if (ImGui.SliderFloat("Linear Hertz", ref m_linearHertz, 0.0f, 20.0f, "%.0f"))
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/DistanceJoint.cs
@@ -128,8 +128,9 @@ public class DistanceJoint : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Distance Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Door.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Door.cs
@@ -91,8 +91,9 @@ public class Door : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Door", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Driving.cs
@@ -215,13 +215,14 @@ public class Driving : Sample
     {
         base.UpdateGui();
 
-        float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(200.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 10.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(16.0f * fontSize, height));
 
         ImGui.Begin("Driving", ImGuiWindowFlags.NoResize);
 
-        ImGui.PushItemWidth(100.0f);
+        ImGui.PushItemWidth(8.0f * fontSize);
         if (ImGui.SliderFloat("Spring Hertz", ref m_hertz, 0.0f, 20.0f, "%.0f"))
         {
             m_car.SetHertz(m_hertz);

--- a/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/GearLift.cs
@@ -296,8 +296,9 @@ public class GearLift : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 120.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 25.0f), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Gear Lift", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/JointSeparation.cs
@@ -177,9 +177,10 @@ public class JointSeparation : Sample
 
     public override void UpdateGui()
     {
-        float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(260.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 14.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(20.0f * fontSize, height));
 
         ImGui.Begin("Joint Separation", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/MotorJoint.cs
@@ -90,9 +90,9 @@ public class MotorJoint : Sample
     {
         base.UpdateGui();
 
-
+        float fontSize = ImGui.GetFontSize();
         float height = 180.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Motor Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/PrismaticJoint.cs
@@ -72,10 +72,10 @@ public class PrismaticJoint : Sample
             B2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
             jointDef.@base.bodyIdA = groundId;
             jointDef.@base.bodyIdB = bodyId;
-            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
-            jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector( axis );
-            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
-            jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector( axis );
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameA.q = b2MakeRotFromUnitVector(axis);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
+            jointDef.@base.localFrameB.q = b2MakeRotFromUnitVector(axis);
             jointDef.@base.drawScale = 2.0f;
             jointDef.motorSpeed = m_motorSpeed;
             jointDef.maxMotorForce = m_motorForce;
@@ -95,8 +95,9 @@ public class PrismaticJoint : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Prismatic Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/Ragdoll.cs
@@ -65,12 +65,13 @@ public class Ragdoll : Sample
     {
         base.UpdateGui();
 
-        float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(180.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 10.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(14.0f * fontSize, height));
 
         ImGui.Begin("Ragdoll", ImGuiWindowFlags.NoResize);
-        ImGui.PushItemWidth(100.0f);
+        ImGui.PushItemWidth(8.0f * fontSize);
 
         if (ImGui.SliderFloat("Friction", ref m_jointFrictionTorque, 0.0f, 1.0f, "%3.2f"))
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/RevoluteJoint.cs
@@ -81,9 +81,9 @@ public class RevoluteJoint : Sample
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
             jointDef.@base.bodyIdA = groundId;
             jointDef.@base.bodyIdB = bodyId;
-            jointDef.@base.localFrameA.q = b2MakeRot( 0.5f * B2_PI );
-            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
-            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
+            jointDef.@base.localFrameA.q = b2MakeRot(0.5f * B2_PI);
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.targetAngle = B2_PI * m_targetDegrees / 180.0f;
             jointDef.enableSpring = m_enableSpring;
             jointDef.hertz = m_hertz;
@@ -96,8 +96,8 @@ public class RevoluteJoint : Sample
             jointDef.enableLimit = m_enableLimit;
 
             m_jointId1 = b2CreateRevoluteJoint(m_worldId, ref jointDef);
-            
-            b2Joint_SetConstraintTuning( m_jointId1, 120.0f, 0.0f );
+
+            b2Joint_SetConstraintTuning(m_jointId1, 120.0f, 0.0f);
         }
 
         {
@@ -130,8 +130,8 @@ public class RevoluteJoint : Sample
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
             jointDef.@base.bodyIdA = groundId;
             jointDef.@base.bodyIdB = body;
-            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdA, pivot );
-            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint( jointDef.@base.bodyIdB, pivot );
+            jointDef.@base.localFrameA.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdA, pivot);
+            jointDef.@base.localFrameB.p = b2Body_GetLocalPoint(jointDef.@base.bodyIdB, pivot);
             jointDef.lowerAngle = -0.25f * B2_PI;
             jointDef.upperAngle = 0.0f * B2_PI;
             jointDef.enableLimit = true;
@@ -147,9 +147,10 @@ public class RevoluteJoint : Sample
     {
         base.UpdateGui();
 
-        float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(240.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 8.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(8.0f * fontSize, height));
 
         ImGui.Begin("Revolute Joint", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Joints/ScaleRagdoll.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/ScaleRagdoll.cs
@@ -61,12 +61,13 @@ public class ScaleRagdoll : Sample
 
     public override void UpdateGui()
     {
-        float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(260.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 4.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(20.0f * fontSize, height));
 
         ImGui.Begin("Scale Ragdoll", ImGuiWindowFlags.NoResize);
-        ImGui.PushItemWidth(200.0f);
+        ImGui.PushItemWidth(15.0f * fontSize);
 
         if (ImGui.SliderFloat("Scale", ref m_scale, 0.1f, 10.0f, "%3.2f", ImGuiSliderFlags.AlwaysClamp))
         {

--- a/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/ScissorLift.cs
@@ -193,8 +193,9 @@ public class ScissorLift : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 140.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Scissor Lift", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
+++ b/src/Box2D.NET.Samples/Samples/Joints/WheelJoint.cs
@@ -89,8 +89,9 @@ public class WheelJoint : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 220.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Wheel Joint", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/Cart.cs
@@ -145,8 +145,9 @@ public class Cart : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_context.camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(320.0f, height));
 
         ImGui.Begin("Cart", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
+++ b/src/Box2D.NET.Samples/Samples/Robustness/OverlapRecovery.cs
@@ -105,8 +105,9 @@ public class OverlapRecovery : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 210.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(220.0f, height));
 
         ImGui.Begin("Overlap Recovery", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ChainShape.cs
@@ -179,18 +179,24 @@ public class ChainShape : Sample
         m_stepCount = 0;
     }
 
-    public override void UpdateGui()
+    public override void Draw(Settings settings)
     {
-        base.UpdateGui();
-
+        base.Draw(settings);
+        
         m_draw.DrawLine(b2Vec2_zero, new B2Vec2(0.5f, 0.0f), B2HexColor.b2_colorRed);
         m_draw.DrawLine(b2Vec2_zero, new B2Vec2(0.0f, 0.5f), B2HexColor.b2_colorGreen);
 
         // DrawTextLine($"toi calls, hits = {b2_toiCalls}, {b2_toiHitCount}");
+    }
 
+    public override void UpdateGui()
+    {
+        base.UpdateGui();
+
+        float fontSize = ImGui.GetFontSize();
         float height = 155.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(240.0f, height));
+        ImGui.SetNextWindowPos( new Vector2( 0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize ), ImGuiCond.Once );
+        ImGui.SetNextWindowSize( new Vector2( 240.0f, height ) );
 
         ImGui.Begin("Chain Shape", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/CompoundShapes.cs
@@ -197,8 +197,9 @@ public class CompoundShapes : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(180.0f, height));
 
         ImGui.Begin("Compound Shapes", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Explosion.cs
@@ -84,8 +84,9 @@ public class Explosion : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Explosion", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/ModifyGeometry.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ModifyGeometry.cs
@@ -18,7 +18,7 @@ namespace Box2D.NET.Samples.Samples.Shapes;
 public class ModifyGeometry : Sample
 {
     private static readonly int SampleModifyGeometry = SampleFactory.Shared.RegisterSample("Shapes", "Modify Geometry", Create);
-    
+
     private B2ShapeId m_shapeId;
     private B2ShapeType m_shapeType;
     private object m_shape;
@@ -111,9 +111,10 @@ public class ModifyGeometry : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(200.0f, height));
 
         ImGui.Begin("Modify Geometry", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/Restitution.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/Restitution.cs
@@ -108,8 +108,9 @@ public class Restitution : Sample
     {
         base.UpdateGui();
 
+        float fontSize = ImGui.GetFontSize();
         float height = 100.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Restitution", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Shapes/ShapeFilter.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/ShapeFilter.cs
@@ -14,7 +14,7 @@ namespace Box2D.NET.Samples.Samples.Shapes;
 public class ShapeFilter : Sample
 {
     private static readonly int SampleShapeFilter = SampleFactory.Shared.RegisterSample("Shapes", "Filter", Create);
-    
+
     public const ulong GROUND = 0x00000001;
     public const ulong TEAM1 = 0x00000002;
     public const ulong TEAM2 = 0x00000004;
@@ -90,9 +90,10 @@ public class ShapeFilter : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 240.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Shape Filter", ImGuiWindowFlags.NoResize);
@@ -209,7 +210,7 @@ public class ShapeFilter : Sample
     public override void Draw(Settings settings)
     {
         base.Draw(settings);
-        
+
         B2Vec2 p1 = b2Body_GetPosition(m_player1Id);
         m_draw.DrawString(new B2Vec2(p1.X - 0.5f, p1.Y), "player 1");
 
@@ -218,6 +219,5 @@ public class ShapeFilter : Sample
 
         B2Vec2 p3 = b2Body_GetPosition(m_player3Id);
         m_draw.DrawString(new B2Vec2(p3.X - 0.5f, p3.Y), "player 3");
-
     }
 }

--- a/src/Box2D.NET.Samples/Samples/Shapes/TangentSpeed.cs
+++ b/src/Box2D.NET.Samples/Samples/Shapes/TangentSpeed.cs
@@ -116,8 +116,9 @@ public class TangentSpeed : Sample
 
     public override void UpdateGui()
     {
+        float fontSize = ImGui.GetFontSize();
         float height = 80.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(260.0f, height));
 
         ImGui.Begin("Ball Parameters", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Stackings/Cliff.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/Cliff.cs
@@ -145,9 +145,10 @@ public class Cliff : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 60.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(160.0f, height));
 
         ImGui.Begin("Cliff", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Stackings/VerticalStack.cs
+++ b/src/Box2D.NET.Samples/Samples/Stackings/VerticalStack.cs
@@ -23,7 +23,7 @@ namespace Box2D.NET.Samples.Samples.Stackings;
 public class VerticalStack : Sample
 {
     private static readonly int SampleVerticalStack = SampleFactory.Shared.RegisterSample("Stacking", "Vertical Stack", Create);
-    
+
     public const int e_maxColumns = 10;
     public const int e_maxRows = 15;
     public const int e_maxBullets = 8;
@@ -67,9 +67,9 @@ public class VerticalStack : Sample
 
             B2Segment segment = new B2Segment(new B2Vec2(10.0f, 0.0f), new B2Vec2(10.0f, 20.0f));
             b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
-            
-            segment = new B2Segment( new B2Vec2(-30.0f, 0.0f ), new B2Vec2( 30.0f, 0.0f ) );
-            b2CreateSegmentShape( groundId, ref shapeDef, ref segment );
+
+            segment = new B2Segment(new B2Vec2(-30.0f, 0.0f), new B2Vec2(30.0f, 0.0f));
+            b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
         }
 
         for (int i = 0; i < e_maxRows * e_maxColumns; ++i)
@@ -223,9 +223,10 @@ public class VerticalStack : Sample
     public override void UpdateGui()
     {
         base.UpdateGui();
-        
+
+        float fontSize = ImGui.GetFontSize();
         float height = 230.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
         ImGui.SetNextWindowSize(new Vector2(240.0f, height));
 
         ImGui.Begin("Vertical Stack", ImGuiWindowFlags.NoResize);

--- a/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
@@ -171,9 +171,10 @@ public class LargeWorld : Sample
     {
         base.UpdateGui();
 
-        float height = 160.0f;
-        ImGui.SetNextWindowPos(new Vector2(10.0f, m_camera.m_height - height - 50.0f), ImGuiCond.Once);
-        ImGui.SetNextWindowSize(new Vector2(240.0f, height));
+        float fontSize = ImGui.GetFontSize();
+        float height = 13.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(18.0f * fontSize, height));
 
         ImGui.Begin("Large World", ImGuiWindowFlags.NoResize);
 

--- a/src/Box2D.NET.Samples/Settings.cs
+++ b/src/Box2D.NET.Samples/Settings.cs
@@ -18,6 +18,7 @@ public class Settings
     public int windowWidth = 1920;
     public int windowHeight = 1080;
 
+    public float uiScale = 1.0f;
     public float hertz = 60.0f;
     public int subStepCount = 4;
     public int workerCount = 1;
@@ -67,6 +68,7 @@ public class Settings
         windowWidth = other.windowWidth;
         windowHeight = other.windowHeight;
 
+        uiScale = other.uiScale;
         hertz = other.hertz;
         subStepCount = other.subStepCount;
         workerCount = other.workerCount;

--- a/src/Box2D.NET/B2Arrays.cs
+++ b/src/Box2D.NET/B2Arrays.cs
@@ -23,6 +23,16 @@ namespace Box2D.NET
     // Cons
     // - cannot debug
     // - breaks code navigation
+    
+    // The fragmentation problem with factor 2:
+    // When you double capacity, the new allocation is larger than the sum of all previous allocations:
+    //
+    // 1st allocation: 8 bytes
+    // 2nd allocation: 16 bytes
+    // 3rd allocation: 32 bytes (larger than 8 + 16 = 24)
+    //
+    // This means the memory freed from previous allocations can never be reused for future expansions
+    // of the same array. The allocator must always find fresh memory.
 
     // todo_erin consider code-gen: https://github.com/IbrahimHindawi/haikal
     public static class B2Arrays

--- a/src/Box2D.NET/B2Body.cs
+++ b/src/Box2D.NET/B2Body.cs
@@ -59,8 +59,9 @@ namespace Box2D.NET
         // Used to check for invalid b2BodyId
         public ushort generation;
 
+        public uint flags;
+
         public bool enableSleep;
-        public bool fixedRotation;
         public bool isSpeedCapped;
         public bool isMarked;
     }

--- a/src/Box2D.NET/B2BodyDef.cs
+++ b/src/Box2D.NET/B2BodyDef.cs
@@ -52,15 +52,15 @@ namespace Box2D.NET
 
         /// Use this to store application specific body data.
         public object userData;
+        
+        /// Motions locks to restrict linear and angular movement
+        public B2MotionLocks motionLocks;
 
         /// Set this flag to false if this body should never fall asleep.
         public bool enableSleep;
 
         /// Is this body initially awake or sleeping?
         public bool isAwake;
-
-        /// Should this body be prevented from rotating? Useful for characters.
-        public bool fixedRotation;
 
         /// Treat this body as high speed object that performs continuous collision detection
         /// against dynamic and kinematic bodies, but not other bullet bodies.

--- a/src/Box2D.NET/B2BodyFlag.cs
+++ b/src/Box2D.NET/B2BodyFlag.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Box2D.NET
+{
+    [Flags]
+    public enum B2BodyFlags
+    {
+        // This body has fixed rotation
+        b2_lockAngularZ = 0x00000001,
+
+        // This body has fixed translation along the x-axis
+        b2_lockLinearX = 0x00000002,
+
+        // This body has fixed translation along the y-axis
+        b2_lockLinearY = 0x00000004,
+
+        // This flag is used for debug draw
+        b2_isFast = 0x00000008,
+
+        // This dynamic body does a final CCD pass against all body types, but not other bullets
+        b2_isBullet = 0x00000010,
+
+        // This body does a CCD pass against sensors
+        b2_enableSensorHits = 0x00000020,
+
+        // This body has hit the maximum linear or angular velocity
+        b2_isSpeedCapped = 0x00000040,
+
+        // This body has no limit on angular velocity
+        b2_allowFastRotation = 0x00000080,
+
+        // This body need's to have its AABB increased
+        b2_enlargeBounds = 0x00000100,
+
+        // All lock flags
+        b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,
+    }
+}

--- a/src/Box2D.NET/B2BodySim.cs
+++ b/src/Box2D.NET/B2BodySim.cs
@@ -8,7 +8,6 @@ namespace Box2D.NET
     // Transform data used for collision and solver preparation.
     public class B2BodySim
     {
-        // todo better to have transform in sim or in @base body? Try both!
         // transform for body origin
         public B2Transform transform;
 
@@ -38,14 +37,7 @@ namespace Box2D.NET
         // body data can be moved around, the id is stable (used in b2BodyId)
         public int bodyId;
 
-        // This flag is used for debug draw
-        public bool isFast;
-
-        public bool isBullet;
-        public bool enableSensorHits;
-        public bool isSpeedCapped;
-        public bool allowFastRotation;
-        public bool enlargeAABB;
+        public uint flags;
 
         public void Clear()
         {
@@ -72,12 +64,7 @@ namespace Box2D.NET
 
             bodyId = 0;
 
-            isFast = false;
-            isBullet = false;
-
-            isSpeedCapped = false;
-            allowFastRotation = false;
-            enlargeAABB = false;
+            flags = 0;
         }
 
         public void CopyFrom(B2BodySim other)
@@ -105,12 +92,7 @@ namespace Box2D.NET
 
             bodyId = other.bodyId;
 
-            isFast = other.isFast;
-            isBullet = other.isBullet;
-
-            isSpeedCapped = other.isSpeedCapped;
-            allowFastRotation = other.allowFastRotation;
-            enlargeAABB = other.enlargeAABB;
+            flags = other.flags;
         }
     }
 }

--- a/src/Box2D.NET/B2BodyState.cs
+++ b/src/Box2D.NET/B2BodyState.cs
@@ -50,7 +50,7 @@ namespace Box2D.NET
             state.CopyFrom(other);
             return state;
         }
-        
+
         public void Clear()
         {
             linearVelocity = new B2Vec2();
@@ -61,15 +61,14 @@ namespace Box2D.NET
 
             deltaRotation = new B2Rot();
         }
-        
+
         public void CopyFrom(B2BodyState other)
         {
             linearVelocity = other.linearVelocity;
             angularVelocity = other.angularVelocity;
             flags = other.flags;
-
+            
             deltaPosition = other.deltaPosition;
-
             deltaRotation = other.deltaRotation;
         }
     }

--- a/src/Box2D.NET/B2ContactFlags.cs
+++ b/src/Box2D.NET/B2ContactFlags.cs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
+using System;
+
 namespace Box2D.NET
 {
     // A contact edge is used to connect bodies and contacts together
@@ -9,6 +11,7 @@ namespace Box2D.NET
     // is an edge. A contact edge belongs to a doubly linked list
     // maintained in each attached body. Each contact has two contact
     // edges, one for each attached body.
+    [Flags]
     public enum B2ContactFlags
     {
         // Set when the solid shapes are touching.

--- a/src/Box2D.NET/B2ContactSimFlags.cs
+++ b/src/Box2D.NET/B2ContactSimFlags.cs
@@ -2,9 +2,12 @@
 // SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
+using System;
+
 namespace Box2D.NET
 {
     // Shifted to be distinct from b2ContactFlags
+    [Flags]
     public enum B2ContactSimFlags
     {
         // Set when the shapes are touching

--- a/src/Box2D.NET/B2Joints.cs
+++ b/src/Box2D.NET/B2Joints.cs
@@ -25,7 +25,7 @@ using static Box2D.NET.B2ConstraintGraphs;
 using static Box2D.NET.B2Islands;
 using static Box2D.NET.B2BoardPhases;
 using static Box2D.NET.B2Solvers;
-
+using static Box2D.NET.B2Ids;
 
 namespace Box2D.NET
 {
@@ -213,6 +213,9 @@ namespace Box2D.NET
         {
             B2_ASSERT(b2IsValidTransform(def.localFrameA));
             B2_ASSERT(b2IsValidTransform(def.localFrameB));
+            B2_ASSERT(world.worldId == def.bodyIdA.world0);
+            B2_ASSERT(world.worldId == def.bodyIdB.world0);
+            B2_ASSERT(B2_ID_EQUALS(def.bodyIdA, def.bodyIdB) == false);
 
             B2Body bodyA = b2GetBodyFullId(world, def.bodyIdA);
             B2Body bodyB = b2GetBodyFullId(world, def.bodyIdB);

--- a/src/Box2D.NET/B2MotionLocks.cs
+++ b/src/Box2D.NET/B2MotionLocks.cs
@@ -1,0 +1,22 @@
+namespace Box2D.NET
+{
+    /// Motion locks to restrict the body movement
+    public struct B2MotionLocks
+    {
+        /// Prevent translation along the x-axis
+        public bool linearX;
+
+        /// Prevent translation along the y-axis
+        public bool linearY;
+
+        /// Prevent rotation around the z-axis
+        public bool angularZ;
+
+        public B2MotionLocks(bool linearX, bool linearY, bool angularZ)
+        {
+            this.linearX = linearX;
+            this.linearY = linearY;
+            this.angularZ = angularZ;
+        }
+    }
+}

--- a/src/Box2D.NET/B2SolverSets.cs
+++ b/src/Box2D.NET/B2SolverSets.cs
@@ -76,6 +76,7 @@ namespace Box2D.NET
                 ref B2BodyState state = ref b2Array_Add(ref awakeSet.bodyStates);
                 //*state = b2_identityBodyState;
                 state.CopyFrom(b2_identityBodyState);
+                state.flags = (int)body.flags;
 
                 // move non-touching contacts from disabled set to awake set
                 int contactKey = body.headContactKey;
@@ -579,6 +580,7 @@ namespace Box2D.NET
                 ref B2BodyState state = ref b2Array_Add(ref targetSet.bodyStates);
                 //*state = b2_identityBodyState;
                 state.CopyFrom(b2_identityBodyState);
+                state.flags = (int)body.flags;
             }
 
             body.setIndex = targetSet.setIndex;

--- a/src/Box2D.NET/B2Types.cs
+++ b/src/Box2D.NET/B2Types.cs
@@ -24,7 +24,7 @@ namespace Box2D.NET
             def.contactSpeed = 3.0f * b2_lengthUnitsPerMeter;
             def.contactHertz = 30.0f;
             def.contactDampingRatio = 10.0f;
-            
+
             // 400 meters per second, faster than the speed of sound
             def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
             def.enableSleep = true;
@@ -88,7 +88,7 @@ namespace Box2D.NET
 
             return material;
         }
-        
+
         /// Use this to initialize your chain definition
         /// @ingroup shape
         public static B2ChainDef b2DefaultChainDef()
@@ -165,6 +165,11 @@ namespace Box2D.NET
             draw.DrawTransformFcn = b2EmptyDrawTransform;
             draw.DrawPointFcn = b2EmptyDrawPoint;
             draw.DrawStringFcn = b2EmptyDrawString;
+
+            draw.drawingBounds.lowerBound = new B2Vec2(-float.MaxValue, -float.MaxValue);
+            draw.drawingBounds.upperBound = new B2Vec2(float.MaxValue, float.MaxValue);
+            draw.useDrawingBounds = true;
+
             return draw;
         }
     }

--- a/src/Box2D.NET/B2Worlds.cs
+++ b/src/Box2D.NET/B2Worlds.cs
@@ -898,7 +898,6 @@ namespace Box2D.NET
             }
         }
 
-
         public static bool DrawQueryCallback(int proxyId, ulong userData, ref B2DrawContext context)
         {
             B2_UNUSED(proxyId);
@@ -938,7 +937,7 @@ namespace Box2D.NET
                 {
                     color = B2HexColor.b2_colorWheat;
                 }
-                else if (bodySim.isBullet && body.setIndex == (int)B2SetType.b2_awakeSet)
+                else if (0 != (bodySim.flags & (uint)B2BodyFlags.b2_isBullet) && body.setIndex == (int)B2SetType.b2_awakeSet)
                 {
                     color = B2HexColor.b2_colorTurquoise;
                 }
@@ -946,7 +945,7 @@ namespace Box2D.NET
                 {
                     color = B2HexColor.b2_colorYellow;
                 }
-                else if (bodySim.isFast)
+                else if (0 != (bodySim.flags & (uint)B2BodyFlags.b2_isFast))
                 {
                     color = B2HexColor.b2_colorSalmon;
                 }
@@ -1245,7 +1244,7 @@ namespace Box2D.NET
                             {
                                 color = B2HexColor.b2_colorWheat;
                             }
-                            else if (bodySim.isBullet && body.setIndex == (int)B2SetType.b2_awakeSet)
+                            else if (0 != (bodySim.flags & (uint)B2BodyFlags.b2_isBullet) && body.setIndex == (int)B2SetType.b2_awakeSet)
                             {
                                 color = B2HexColor.b2_colorTurquoise;
                             }
@@ -1253,7 +1252,7 @@ namespace Box2D.NET
                             {
                                 color = B2HexColor.b2_colorYellow;
                             }
-                            else if (bodySim.isFast)
+                            else if (0 != (bodySim.flags & (uint)B2BodyFlags.b2_isFast))
                             {
                                 color = B2HexColor.b2_colorSalmon;
                             }


### PR DESCRIPTION
[upstream] https://github.com/erincatto/box2d/pull/950

Removed `b2BodyDef::fixedRotation`
Added `b2MotionLocks`
Added `b2BodyDef::motionLocks`

Removed `b2Body_SetFixedRotation` and `b2Body_IsFixedRotation` Added `b2Body_SetMotionLocks` and `b2Body_GetMotionLocks`

Motion locking is now done by effectively applying a velocity constraint in the solver. This means
bodies with fixed translation or rotation will have regular mass properties.

Also motion locking may not always keep locked velocities zero. However, they will become zero after `b2World_Step`.

Some functions may set the locked velocities to zero to avoid waking the body.

UI scaling improvements in the sample app.