### PR TITLE
[upstream] Remove cancellation from inertia calculation to improve ac…

### DIFF
--- a/src/Box2D.NET.Samples/Samples/Issues/BadSteiner.cs
+++ b/src/Box2D.NET.Samples/Samples/Issues/BadSteiner.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using static Box2D.NET.B2Geometries;
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Hulls;
+
+namespace Box2D.NET.Samples.Samples.Issues;
+
+public class BadSteiner : Sample
+{
+    private static readonly int SampleBadSteiner = SampleFactory.Shared.RegisterSample("Issues", "Bad Steiner", Create);
+
+    private static Sample Create(SampleContext context)
+    {
+        return new BadSteiner(context);
+    }
+
+    public BadSteiner(SampleContext context) : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.0f, 1.75f);
+            m_context.camera.m_zoom = 2.5f;
+        }
+
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            B2BodyId groundId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            B2Segment segment = new B2Segment(new B2Vec2(-100.0f, 0.0f), new B2Vec2(100.0f, 0.0f));
+            b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
+        }
+
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.type = B2BodyType.b2_dynamicBody;
+            bodyDef.position = new B2Vec2(-48.0f, 62.0f);
+            B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+
+            B2Vec2[] points =
+            [
+                new B2Vec2(48.7599983f, -60.5699997f),
+                new B2Vec2(48.7400017f, -60.5400009f),
+                new B2Vec2(48.6800003f, -60.5600014f)
+            ];
+
+            B2Hull hull = b2ComputeHull(points, 3);
+            B2Polygon poly = b2MakePolygon(ref hull, 0.0f);
+            b2CreatePolygonShape(bodyId, ref shapeDef, ref poly);
+        }
+    }
+}

--- a/src/Box2D.NET/B2Geometries.cs
+++ b/src/Box2D.NET/B2Geometries.cs
@@ -257,8 +257,8 @@ namespace Box2D.NET
             massData.mass = density * B2_PI * rr;
             massData.center = shape.center;
 
-            // inertia about the local origin
-            massData.rotationalInertia = massData.mass * (0.5f * rr + b2Dot(shape.center, shape.center));
+            // inertia about the center of mass
+            massData.rotationalInertia = massData.mass * 0.5f * rr;
 
             return massData;
         }
@@ -299,9 +299,6 @@ namespace Box2D.NET
             float circleInertia = circleMass * (0.5f * rr + h * h + 2.0f * h * lc);
             float boxInertia = boxMass * (4.0f * rr + ll) / 12.0f;
             massData.rotationalInertia = circleInertia + boxInertia;
-
-            // inertia about the local origin
-            massData.rotationalInertia += massData.mass * b2Dot(massData.center, massData.center);
 
             return massData;
         }
@@ -424,8 +421,11 @@ namespace Box2D.NET
             // Inertia tensor relative to the local origin (point s).
             massData.rotationalInertia = density * rotationalInertia;
 
-            // Shift to center of mass then to original body origin.
-            massData.rotationalInertia += massData.mass * (b2Dot(massData.center, massData.center) - b2Dot(center, center));
+            // Shift inertia to center of mass
+            massData.rotationalInertia -= massData.mass * b2Dot(center, center);
+
+            // If this goes negative we are hosed
+            B2_ASSERT(massData.rotationalInertia >= 0.0f);
 
             return massData;
         }

--- a/src/Box2D.NET/B2MassData.cs
+++ b/src/Box2D.NET/B2MassData.cs
@@ -13,7 +13,7 @@ namespace Box2D.NET
         /// The position of the shape's centroid relative to the shape's origin.
         public B2Vec2 center;
 
-        /// The rotational inertia of the shape about the local origin.
+        /// The rotational inertia of the shape about the shape center.
         public float rotationalInertia;
 
         public B2MassData(float mass, B2Vec2 center, float rotationalInertia)

--- a/test/Box2D.NET.Test/B2ShapeTest.cs
+++ b/test/Box2D.NET.Test/B2ShapeTest.cs
@@ -28,7 +28,7 @@ public class B2ShapeTest
             Assert.That(md.mass - B2_PI, Is.LessThan(FLT_EPSILON));
             Assert.That(md.center.X, Is.EqualTo(1.0f));
             Assert.That(md.center.Y, Is.EqualTo(0.0f));
-            Assert.That(md.rotationalInertia - 1.5f * B2_PI, Is.LessThan(FLT_EPSILON));
+            Assert.That(md.rotationalInertia - 0.5f * B2_PI, Is.LessThan(FLT_EPSILON));
         }
 
         {


### PR DESCRIPTION
…curacy (box2d #955)

I was computing the shape inertia about the body origin and then shifting to the center of mass. But this involves quadratic math with bad cancellation effects.

I'm now buffering the shape inertias about their centroids and then shifting them to the final body center of mass. This removes the quadratic cancellation.

Fixes (box2d #949)