### PR TITLE
[upstream] Bug fixes (box2d #956)

### DIFF
--- a/src/Box2D.NET.Samples/Draw.cs
+++ b/src/Box2D.NET.Samples/Draw.cs
@@ -59,7 +59,6 @@ public class Draw
         m_debugDraw.DrawStringFcn = DrawStringFcn;
         m_debugDraw.drawingBounds = bounds;
 
-        m_debugDraw.useDrawingBounds = false;
         m_debugDraw.drawShapes = true;
         m_debugDraw.drawJoints = true;
         m_debugDraw.drawJointExtras = false;

--- a/src/Box2D.NET.Samples/SampleApp.cs
+++ b/src/Box2D.NET.Samples/SampleApp.cs
@@ -294,7 +294,6 @@ public class SampleApp
             // #todo restore all drawing settings that may have been overridden by a sample
             _context.settings.subStepCount = 4;
             _context.settings.drawJoints = true;
-            _context.settings.useCameraBounds = true;
 
             s_sample?.Dispose();
             s_sample = null;

--- a/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
+++ b/src/Box2D.NET.Samples/Samples/Bodies/BodyType.cs
@@ -47,6 +47,7 @@ public class BodyType : Sample
         B2BodyId groundId = b2_nullBodyId;
         {
             B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "ground";
             groundId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Segment segment = new B2Segment(new B2Vec2(-20.0f, 0.0f), new B2Vec2(20.0f, 0.0f));
@@ -59,6 +60,7 @@ public class BodyType : Sample
             B2BodyDef bodyDef = b2DefaultBodyDef();
             bodyDef.type = B2BodyType.b2_dynamicBody;
             bodyDef.position = new B2Vec2(-2.0f, 3.0f);
+            bodyDef.name = "attach1";
             m_attachmentId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Polygon box = b2MakeBox(0.5f, 2.0f);
@@ -73,6 +75,7 @@ public class BodyType : Sample
             bodyDef.type = m_type;
             bodyDef.isEnabled = m_isEnabled;
             bodyDef.position = new B2Vec2(3.0f, 3.0f);
+            bodyDef.name = "attach2";
             m_secondAttachmentId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Polygon box = b2MakeBox(0.5f, 2.0f);
@@ -87,6 +90,7 @@ public class BodyType : Sample
             bodyDef.type = m_type;
             bodyDef.isEnabled = m_isEnabled;
             bodyDef.position = new B2Vec2(-4.0f, 5.0f);
+            bodyDef.name = "platform";
             m_platformId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Polygon box = b2MakeOffsetBox(0.5f, 4.0f, new B2Vec2(4.0f, 0.0f), b2MakeRot(0.5f * B2_PI));
@@ -137,6 +141,7 @@ public class BodyType : Sample
             B2BodyDef bodyDef = b2DefaultBodyDef();
             bodyDef.type = B2BodyType.b2_dynamicBody;
             bodyDef.position = new B2Vec2(-3.0f, 8.0f);
+            bodyDef.name = "crate1";
             B2BodyId bodyId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Polygon box = b2MakeBox(0.75f, 0.75f);
@@ -153,6 +158,7 @@ public class BodyType : Sample
             bodyDef.type = m_type;
             bodyDef.isEnabled = m_isEnabled;
             bodyDef.position = new B2Vec2(2.0f, 8.0f);
+            bodyDef.name = "crate2";
             m_secondPayloadId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Polygon box = b2MakeBox(0.75f, 0.75f);
@@ -169,6 +175,7 @@ public class BodyType : Sample
             bodyDef.type = m_type;
             bodyDef.isEnabled = m_isEnabled;
             bodyDef.position = new B2Vec2(8.0f, 0.2f);
+            bodyDef.name = "debris";
             m_touchingBodyId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Capsule capsule = new B2Capsule(new B2Vec2(0.0f, 0.0f), new B2Vec2(1.0f, 0.0f), 0.25f);
@@ -186,6 +193,7 @@ public class BodyType : Sample
             bodyDef.isEnabled = m_isEnabled;
             bodyDef.position = new B2Vec2(-8.0f, 12.0f);
             bodyDef.gravityScale = 0.0f;
+            bodyDef.name = "floater";
             m_floatingBodyId = b2CreateBody(m_worldId, ref bodyDef);
 
             B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.5f), 0.25f);
@@ -221,6 +229,9 @@ public class BodyType : Sample
         {
             m_type = B2BodyType.b2_kinematicBody;
             b2Body_SetType(m_platformId, B2BodyType.b2_kinematicBody);
+            b2Body_SetLinearVelocity(m_secondAttachmentId, b2Vec2_zero);
+            b2Body_SetAngularVelocity(m_secondAttachmentId, 0.0f);
+
             b2Body_SetLinearVelocity(m_platformId, new B2Vec2(-m_speed, 0.0f));
             b2Body_SetAngularVelocity(m_platformId, 0.0f);
             b2Body_SetType(m_secondAttachmentId, B2BodyType.b2_kinematicBody);
@@ -243,24 +254,14 @@ public class BodyType : Sample
         {
             if (m_isEnabled)
             {
-                b2Body_Enable(m_platformId);
-                b2Body_Enable(m_secondAttachmentId);
+                b2Body_Enable(m_attachmentId);
                 b2Body_Enable(m_secondPayloadId);
-                b2Body_Enable(m_touchingBodyId);
                 b2Body_Enable(m_floatingBodyId);
-
-                if (m_type == B2BodyType.b2_kinematicBody)
-                {
-                    b2Body_SetLinearVelocity(m_platformId, new B2Vec2(-m_speed, 0.0f));
-                    b2Body_SetAngularVelocity(m_platformId, 0.0f);
-                }
             }
             else
             {
-                b2Body_Disable(m_platformId);
-                b2Body_Disable(m_secondAttachmentId);
+                b2Body_Disable(m_attachmentId);
                 b2Body_Disable(m_secondPayloadId);
-                b2Body_Disable(m_touchingBodyId);
                 b2Body_Disable(m_floatingBodyId);
             }
         }

--- a/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
+++ b/src/Box2D.NET.Samples/Samples/Continuous/BounceHouse.cs
@@ -68,7 +68,7 @@ public class BounceHouse : Sample
             b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
         }
 
-        m_shapeType = ShapeType.e_boxShape;
+        m_shapeType = ShapeType.e_circleShape;
         m_bodyId = b2_nullBodyId;
         m_enableHitEvents = true;
 
@@ -93,6 +93,7 @@ public class BounceHouse : Sample
         bodyDef.linearVelocity = new B2Vec2(10.0f, 20.0f);
         bodyDef.position = new B2Vec2(0.0f, 0.0f);
         bodyDef.gravityScale = 0.0f;
+        bodyDef.isBullet = true;
 
         // Circle shapes centered on the body can spin fast without risk of tunnelling.
         bodyDef.allowFastRotation = m_shapeType == ShapeType.e_circleShape;
@@ -101,8 +102,8 @@ public class BounceHouse : Sample
 
         B2ShapeDef shapeDef = b2DefaultShapeDef();
         shapeDef.density = 1.0f;
-        shapeDef.material.restitution = 1.2f;
-        shapeDef.material.friction = 0.3f;
+        shapeDef.material.restitution = 1.0f;
+        shapeDef.material.friction = 0.0f;
         shapeDef.enableHitEvents = m_enableHitEvents;
 
         if (m_shapeType == ShapeType.e_circleShape)

--- a/src/Box2D.NET.Samples/Samples/Issues/Crash01.cs
+++ b/src/Box2D.NET.Samples/Samples/Issues/Crash01.cs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System.Numerics;
+using ImGuiNET;
+using static Box2D.NET.B2Joints;
+using static Box2D.NET.B2Geometries;
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2MathFunction;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+using static Box2D.NET.B2Ids;
+
+namespace Box2D.NET.Samples.Samples.Issues;
+
+public class Crash01 : Sample
+{
+    private static readonly int SampleBodyType = SampleFactory.Shared.RegisterSample("Issues", "Crash01", Create);
+
+    private B2BodyId m_attachmentId;
+    private B2BodyId m_platformId;
+    private B2BodyType m_type;
+    private bool m_isEnabled;
+
+    private static Sample Create(SampleContext context)
+    {
+        return new Crash01(context);
+    }
+
+    public Crash01(SampleContext context) : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.8f, 6.4f);
+            m_context.camera.m_zoom = 25.0f * 0.4f;
+        }
+
+        m_type = B2BodyType.b2_dynamicBody;
+        m_isEnabled = true;
+
+        B2BodyId groundId = b2_nullBodyId;
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.name = "ground";
+            groundId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Segment segment = new B2Segment(new B2Vec2(-20.0f, 0.0f), new B2Vec2(20.0f, 0.0f));
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            b2CreateSegmentShape(groundId, ref shapeDef, ref segment);
+        }
+
+        // Define attachment
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.type = B2BodyType.b2_dynamicBody;
+            bodyDef.position = new B2Vec2(-2.0f, 3.0f);
+            bodyDef.name = "attach1";
+            m_attachmentId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Polygon box = b2MakeBox(0.5f, 2.0f);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.density = 1.0f;
+            b2CreatePolygonShape(m_attachmentId, ref shapeDef, ref box);
+        }
+
+        // Define platform
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.type = m_type;
+            bodyDef.isEnabled = m_isEnabled;
+            bodyDef.position = new B2Vec2(-4.0f, 5.0f);
+            bodyDef.name = "platform";
+            m_platformId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Polygon box = b2MakeOffsetBox(0.5f, 4.0f, new B2Vec2(4.0f, 0.0f), b2MakeRot(0.5f * B2_PI));
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            shapeDef.density = 2.0f;
+            b2CreatePolygonShape(m_platformId, ref shapeDef, ref box);
+
+            B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
+            B2Vec2 pivot = new B2Vec2(-2.0f, 5.0f);
+            revoluteDef.@base.bodyIdA = m_attachmentId;
+            revoluteDef.@base.bodyIdB = m_platformId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(m_attachmentId, pivot);
+            revoluteDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, pivot);
+            revoluteDef.maxMotorTorque = 50.0f;
+            revoluteDef.enableMotor = true;
+            b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
+
+            B2PrismaticJointDef prismaticDef = b2DefaultPrismaticJointDef();
+            B2Vec2 anchor = new B2Vec2(0.0f, 5.0f);
+            prismaticDef.@base.bodyIdA = groundId;
+            prismaticDef.@base.bodyIdB = m_platformId;
+            prismaticDef.@base.localFrameA.p = b2Body_GetLocalPoint(groundId, anchor);
+            prismaticDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, anchor);
+            prismaticDef.maxMotorForce = 1000.0f;
+            prismaticDef.motorSpeed = 0.0f;
+            prismaticDef.enableMotor = true;
+            prismaticDef.lowerTranslation = -10.0f;
+            prismaticDef.upperTranslation = 10.0f;
+            prismaticDef.enableLimit = true;
+
+            b2CreatePrismaticJoint(m_worldId, ref prismaticDef);
+        }
+    }
+
+    public override void UpdateGui()
+    {
+        float fontSize = ImGui.GetFontSize();
+        float height = 11.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(0.5f * fontSize, m_camera.m_height - height - 2.0f * fontSize), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(9.0f * fontSize, height));
+        ImGui.Begin("Crash 01", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
+
+        if (ImGui.RadioButton("Static", m_type == B2BodyType.b2_staticBody))
+        {
+            m_type = B2BodyType.b2_staticBody;
+            b2Body_SetType(m_platformId, B2BodyType.b2_staticBody);
+        }
+
+        if (ImGui.RadioButton("Kinematic", m_type == B2BodyType.b2_kinematicBody))
+        {
+            m_type = B2BodyType.b2_kinematicBody;
+            b2Body_SetType(m_platformId, B2BodyType.b2_kinematicBody);
+            b2Body_SetLinearVelocity(m_platformId, new B2Vec2(-0.1f, 0.0f));
+        }
+
+        if (ImGui.RadioButton("Dynamic", m_type == B2BodyType.b2_dynamicBody))
+        {
+            m_type = B2BodyType.b2_dynamicBody;
+            b2Body_SetType(m_platformId, B2BodyType.b2_dynamicBody);
+        }
+
+        if (ImGui.Checkbox("Enable", ref m_isEnabled))
+        {
+            if (m_isEnabled)
+            {
+                b2Body_Enable(m_attachmentId);
+            }
+            else
+            {
+                b2Body_Disable(m_attachmentId);
+            }
+        }
+
+        ImGui.End();
+    }
+}

--- a/src/Box2D.NET.Samples/Samples/Issues/DisableCrash.cs
+++ b/src/Box2D.NET.Samples/Samples/Issues/DisableCrash.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 Erin Catto
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System.Numerics;
+using ImGuiNET;
+using static Box2D.NET.B2Joints;
+using static Box2D.NET.B2Geometries;
+using static Box2D.NET.B2Types;
+using static Box2D.NET.B2MathFunction;
+using static Box2D.NET.B2Bodies;
+using static Box2D.NET.B2Shapes;
+
+namespace Box2D.NET.Samples.Samples.Issues;
+
+public class DisableCrash : Sample
+{
+    private static readonly int SampleDisableCrash = SampleFactory.Shared.RegisterSample("Issues", "Disable", Create);
+
+    private B2BodyId m_attachmentId;
+    private B2BodyId m_platformId;
+    bool m_isEnabled;
+
+    private static Sample Create(SampleContext context)
+    {
+        return new DisableCrash(context);
+    }
+
+    public DisableCrash(SampleContext context)
+        : base(context)
+    {
+        if (m_context.settings.restart == false)
+        {
+            m_context.camera.m_center = new B2Vec2(0.8f, 6.4f);
+            m_context.camera.m_zoom = 25.0f * 0.4f;
+        }
+
+        m_isEnabled = true;
+
+        // Define attachment
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.type = B2BodyType.b2_dynamicBody;
+            bodyDef.position = new B2Vec2(-2.0f, 3.0f);
+            bodyDef.isEnabled = m_isEnabled;
+            m_attachmentId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Polygon box = b2MakeBox(0.5f, 2.0f);
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            b2CreatePolygonShape(m_attachmentId, ref shapeDef, ref box);
+        }
+
+        // Define platform
+        {
+            B2BodyDef bodyDef = b2DefaultBodyDef();
+            bodyDef.position = new B2Vec2(-4.0f, 5.0f);
+            m_platformId = b2CreateBody(m_worldId, ref bodyDef);
+
+            B2Polygon box = b2MakeOffsetBox(0.5f, 4.0f, new B2Vec2(4.0f, 0.0f), b2MakeRot(0.5f * B2_PI));
+
+            B2ShapeDef shapeDef = b2DefaultShapeDef();
+            b2CreatePolygonShape(m_platformId, ref shapeDef, ref box);
+
+            B2RevoluteJointDef revoluteDef = b2DefaultRevoluteJointDef();
+            B2Vec2 pivot = new B2Vec2(-2.0f, 5.0f);
+            revoluteDef.@base.bodyIdA = m_attachmentId;
+            revoluteDef.@base.bodyIdB = m_platformId;
+            revoluteDef.@base.localFrameA.p = b2Body_GetLocalPoint(m_attachmentId, pivot);
+            revoluteDef.@base.localFrameB.p = b2Body_GetLocalPoint(m_platformId, pivot);
+            revoluteDef.maxMotorTorque = 50.0f;
+            revoluteDef.enableMotor = true;
+            b2CreateRevoluteJoint(m_worldId, ref revoluteDef);
+        }
+    }
+
+    public override void UpdateGui()
+    {
+        float fontSize = ImGui.GetFontSize();
+        float height = 11.0f * fontSize;
+        float winX = 0.5f * fontSize;
+        float winY = m_camera.m_height - height - 2.0f * fontSize;
+        ImGui.SetNextWindowPos(new Vector2(winX, winY), ImGuiCond.Once);
+        ImGui.SetNextWindowSize(new Vector2(9.0f * fontSize, height));
+        ImGui.Begin("Disable Crash", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
+
+        if (ImGui.Checkbox("Enable", ref m_isEnabled))
+        {
+            if (m_isEnabled)
+            {
+                b2Body_Enable(m_attachmentId);
+            }
+            else
+            {
+                b2Body_Disable(m_attachmentId);
+            }
+        }
+
+        ImGui.End();
+    }
+}

--- a/src/Box2D.NET.Samples/Samples/Sample.cs
+++ b/src/Box2D.NET.Samples/Samples/Sample.cs
@@ -466,7 +466,6 @@ public class Sample : IDisposable
         }
 
         m_context.draw.m_debugDraw.drawingBounds = m_camera.GetViewBounds();
-        m_context.draw.m_debugDraw.useDrawingBounds = settings.useCameraBounds;
         m_context.draw.m_debugDraw.drawShapes = settings.drawShapes;
         m_context.draw.m_debugDraw.drawJoints = settings.drawJoints;
         m_context.draw.m_debugDraw.drawJointExtras = settings.drawJointExtras;

--- a/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
+++ b/src/Box2D.NET.Samples/Samples/Worlds/LargeWorld.cs
@@ -58,7 +58,6 @@ public class LargeWorld : Sample
             m_camera.m_center = m_viewPosition;
             m_camera.m_zoom = 25.0f * 1.0f;
             m_context.settings.drawJoints = false;
-            m_context.settings.useCameraBounds = true;
         }
 
         {

--- a/src/Box2D.NET.Samples/Settings.cs
+++ b/src/Box2D.NET.Samples/Settings.cs
@@ -23,7 +23,6 @@ public class Settings
     public int subStepCount = 4;
     public int workerCount = 1;
 
-    public bool useCameraBounds = false;
     public bool drawShapes = true;
     public bool drawJoints = true;
     public bool drawJointExtras = false;
@@ -73,7 +72,6 @@ public class Settings
         subStepCount = other.subStepCount;
         workerCount = other.workerCount;
 
-        useCameraBounds = other.useCameraBounds;
         drawShapes = other.drawShapes;
         drawJoints = other.drawJoints;
         drawJointExtras = other.drawJointExtras;

--- a/src/Box2D.NET.Shared/Benchmarks.cs
+++ b/src/Box2D.NET.Shared/Benchmarks.cs
@@ -44,6 +44,8 @@ namespace Box2D.NET.Shared
             B2Circle circle = new B2Circle(new B2Vec2(0.0f, 0.0f), 0.4f);
 
             B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
+            jointDef.@base.drawScale = 0.4f;
+
             B2BodyDef bodyDef = b2DefaultBodyDef();
 
             for (int k = 0; k < N; ++k)
@@ -360,7 +362,8 @@ namespace Box2D.NET.Shared
                 b2CreatePolygonShape(spinnerId, ref shapeDef, ref box);
 
                 float motorSpeed = 5.0f;
-                float maxMotorTorque = 40000.0f;
+                //float maxMotorTorque = 100.0f * 40000.0f;
+                float maxMotorTorque = float.MaxValue;
                 B2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
                 jointDef.@base.bodyIdA = groundId;
                 jointDef.@base.bodyIdB = spinnerId;
@@ -384,9 +387,9 @@ namespace Box2D.NET.Shared
                 shapeDef.material.restitution = 0.1f;
                 shapeDef.density = 0.25f;
 
-                int bodyCount = BENCHMARK_DEBUG ? 499 : 3038;
+                int bodyCount = BENCHMARK_DEBUG ? 499 : 2 * 3038;
 
-                float x = -24.0f, y = 2.0f;
+                float x = -23.0f, y = 2.0f;
                 for (int i = 0; i < bodyCount; ++i)
                 {
                     bodyDef.position = new B2Vec2(x, y);
@@ -406,12 +409,12 @@ namespace Box2D.NET.Shared
                         b2CreatePolygonShape(bodyId, ref shapeDef, ref square);
                     }
 
-                    x += 1.0f;
+                    x += 0.5f;
 
-                    if (x > 24.0f)
+                    if (x >= 23.0f)
                     {
-                        x = -24.0f;
-                        y += 1.0f;
+                        x = -23.0f;
+                        y += 0.5f;
                     }
                 }
             }

--- a/src/Box2D.NET.Shared/Determinism.cs
+++ b/src/Box2D.NET.Shared/Determinism.cs
@@ -58,7 +58,7 @@ namespace Box2D.NET.Shared
                 jointDef.dampingRatio = 0.5f;
                 jointDef.@base.localFrameA.p = new B2Vec2(h, h);
                 jointDef.@base.localFrameB.p = new B2Vec2(offset, -h);
-                jointDef.@base.drawScale = 0.1f;
+                jointDef.@base.drawScale = 0.5f;
 
                 int bodyIndex = 0;
 

--- a/src/Box2D.NET/B2BitSets.cs
+++ b/src/Box2D.NET/B2BitSets.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.CompilerServices;
 using static Box2D.NET.B2Diagnostics;
 using static Box2D.NET.B2Buffers;
+using static Box2D.NET.B2CTZs;
 
 namespace Box2D.NET
 {
@@ -123,6 +124,20 @@ namespace Box2D.NET
             }
 
             bitSet.blockCount = blockCount;
+        }
+
+        // This function is here because ctz.h is included by
+        // this file but not in bitset.c
+        public static int b2CountSetBits(ref B2BitSet set)
+        {
+            int popCount = 0;
+            int blockCount = set.blockCount;
+            for (uint i = 0; i < blockCount; ++i)
+            {
+                popCount += b2PopCount64(set.bits[i]);
+            }
+
+            return popCount;
         }
 
         public static void b2InPlaceUnion(ref B2BitSet setA, ref B2BitSet setB)

--- a/src/Box2D.NET/B2Body.cs
+++ b/src/Box2D.NET/B2Body.cs
@@ -64,7 +64,6 @@ namespace Box2D.NET
 
         // todo move into flags
         public bool enableSleep;
-        public bool isSpeedCapped;
         public bool isMarked;
     }
 }

--- a/src/Box2D.NET/B2BodyFlags.cs
+++ b/src/Box2D.NET/B2BodyFlags.cs
@@ -20,14 +20,17 @@ namespace Box2D.NET
         // This dynamic body does a final CCD pass against all body types, but not other bullets
         b2_isBullet = 0x00000010,
 
-        // This body has hit the maximum linear or angular velocity
+        // This body was speed capped in the current time step
         b2_isSpeedCapped = 0x00000020,
+	
+        // This body had a time of impact event in the current time step
+        b2_hadTimeOfImpact = 0x00000040,
 
         // This body has no limit on angular velocity
-        b2_allowFastRotation = 0x00000040,
+        b2_allowFastRotation = 0x00000080,
 
         // This body need's to have its AABB increased
-        b2_enlargeBounds = 0x00000080,
+        b2_enlargeBounds = 0x00000100,
 
         // All lock flags
         b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,

--- a/src/Box2D.NET/B2CTZs.cs
+++ b/src/Box2D.NET/B2CTZs.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Box2D.NET
@@ -19,6 +20,7 @@ namespace Box2D.NET
                 count++;
                 block >>= 1;
             }
+
             return count;
         }
 
@@ -34,6 +36,7 @@ namespace Box2D.NET
                 count++;
                 mask >>= 1;
             }
+
             return count;
         }
 
@@ -48,6 +51,20 @@ namespace Box2D.NET
                 count++;
                 block >>= 1;
             }
+
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int b2PopCount64(ulong block)
+        {
+            int count = 0;
+            while (block != 0)
+            {
+                count += (int)(block & 1);
+                block >>= 1;
+            }
+
             return count;
         }
 

--- a/src/Box2D.NET/B2Constants.cs
+++ b/src/Box2D.NET/B2Constants.cs
@@ -17,7 +17,7 @@ namespace Box2D.NET
 
         // Maximum number of colors in the constraint graph. Constraints that cannot
         // find a color are added to the overflow set which are solved single-threaded.
-        public const int B2_GRAPH_COLOR_COUNT = 12;
+        public const int B2_GRAPH_COLOR_COUNT = 24;
 
         // A small length used as a collision and constraint tolerance. Usually it is
         // chosen to be numerically significant, but visually insignificant. In meters.

--- a/src/Box2D.NET/B2ContactSolvers.cs
+++ b/src/Box2D.NET/B2ContactSolvers.cs
@@ -1695,12 +1695,15 @@ static void b2ScatterBodies( b2BodyState* states, int* indices, const b2BodyStat
 
                     // Clamp the accumulated impulse
                     B2FloatW newImpulse = b2MaxW(b2SubW(c.normalImpulse1, negImpulse), b2ZeroW());
-                    B2FloatW impulse = b2SubW(newImpulse, c.normalImpulse1);
+                    B2FloatW deltaImpulse = b2SubW(newImpulse, c.normalImpulse1);
                     c.normalImpulse1 = newImpulse;
 
+                    // Add the incremental impulse rather than the full impulse because this is not a sub-step
+                    c.totalNormalImpulse1 = b2AddW(c.totalNormalImpulse1, deltaImpulse);
+
                     // Apply contact impulse
-                    B2FloatW Px = b2MulW(impulse, c.normal.X);
-                    B2FloatW Py = b2MulW(impulse, c.normal.Y);
+                    B2FloatW Px = b2MulW(deltaImpulse, c.normal.X);
+                    B2FloatW Py = b2MulW(deltaImpulse, c.normal.Y);
 
                     bA.v.X = b2MulSubW(bA.v.X, c.invMassA, Px);
                     bA.v.Y = b2MulSubW(bA.v.Y, c.invMassA, Py);
@@ -1733,12 +1736,15 @@ static void b2ScatterBodies( b2BodyState* states, int* indices, const b2BodyStat
 
                     // Clamp the accumulated impulse
                     B2FloatW newImpulse = b2MaxW(b2SubW(c.normalImpulse2, negImpulse), b2ZeroW());
-                    B2FloatW impulse = b2SubW(newImpulse, c.normalImpulse2);
+                    B2FloatW deltaImpulse = b2SubW(newImpulse, c.normalImpulse2);
                     c.normalImpulse2 = newImpulse;
 
+                    // Add the incremental impulse rather than the full impulse because this is not a sub-step
+                    c.totalNormalImpulse2 = b2AddW(c.totalNormalImpulse2, deltaImpulse);
+
                     // Apply contact impulse
-                    B2FloatW Px = b2MulW(impulse, c.normal.X);
-                    B2FloatW Py = b2MulW(impulse, c.normal.Y);
+                    B2FloatW Px = b2MulW(deltaImpulse, c.normal.X);
+                    B2FloatW Py = b2MulW(deltaImpulse, c.normal.Y);
 
                     bA.v.X = b2MulSubW(bA.v.X, c.invMassA, Px);
                     bA.v.Y = b2MulSubW(bA.v.Y, c.invMassA, Py);

--- a/src/Box2D.NET/B2Contacts.cs
+++ b/src/Box2D.NET/B2Contacts.cs
@@ -462,7 +462,6 @@ namespace Box2D.NET
             contactSim.friction = world.frictionCallback(shapeA.friction, shapeA.userMaterialId, shapeB.friction, shapeB.userMaterialId);
             contactSim.restitution = world.restitutionCallback(shapeA.restitution, shapeA.userMaterialId, shapeB.restitution, shapeB.userMaterialId);
 
-            // todo branch improves perf?
             if (shapeA.rollingResistance > 0.0f || shapeB.rollingResistance > 0.0f)
             {
                 float radiusA = b2GetShapeRadius(shapeA);

--- a/src/Box2D.NET/B2Counters.cs
+++ b/src/Box2D.NET/B2Counters.cs
@@ -17,6 +17,6 @@ namespace Box2D.NET
         public int treeHeight;
         public int byteCount;
         public int taskCount;
-        public B2FixedArray12<int> colorCounts;
+        public B2FixedArray24<int> colorCounts;
     }
 }

--- a/src/Box2D.NET/B2DebugDraw.cs
+++ b/src/Box2D.NET/B2DebugDraw.cs
@@ -22,9 +22,6 @@ namespace Box2D.NET
         /// Bounds to use if restricting drawing to a rectangular region
         public B2AABB drawingBounds;
 
-        /// Option to restrict drawing to a rectangular region. May suffer from unstable depth sorting.
-        public bool useDrawingBounds;
-
         /// Option to draw shapes
         public bool drawShapes;
 

--- a/src/Box2D.NET/B2FixedArray24.cs
+++ b/src/Box2D.NET/B2FixedArray24.cs
@@ -1,0 +1,57 @@
+﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable CS0169
+
+namespace Box2D.NET
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct B2FixedArray24<T> where T : unmanaged
+    {
+        public const int Size = 24;
+
+        private T _v0000;
+        private T _v0001;
+        private T _v0002;
+        private T _v0003;
+        private T _v0004;
+        private T _v0005;
+        private T _v0006;
+        private T _v0007;
+        private T _v0008;
+        private T _v0009;
+        private T _v0010;
+        private T _v0011;
+        private T _v0012;
+        private T _v0013;
+        private T _v0014;
+        private T _v0015;
+        private T _v0016;
+        private T _v0017;
+        private T _v0018;
+        private T _v0019;
+        private T _v0020;
+        private T _v0021;
+        private T _v0022;
+        private T _v0023;
+
+        public int Length => Size;
+
+        public ref T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ref AsSpan()[index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> AsSpan()
+        {
+            return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+    }
+}

--- a/src/Box2D.NET/B2GraphColor.cs
+++ b/src/Box2D.NET/B2GraphColor.cs
@@ -11,7 +11,11 @@ namespace Box2D.NET
         // This bitset is indexed by bodyId so this is over-sized to encompass static bodies
         // however I never traverse these bits or use the bit count for anything
         // This bitset is unused on the overflow color.
-        // todo consider having a uint_16 per body that tracks the graph color membership
+        //
+        // Dirk suggested having a uint64_t per body that tracks the graph color membership
+        // but I think this would make debugging harder and be less flexible. With the bitset
+        // I can trivially increase the number of graph colors beyond 64. See usage of b2CountSetBits
+        // for validation.
         public B2BitSet bodySet;
 
         // cache friendly arrays

--- a/src/Box2D.NET/B2Islands.cs
+++ b/src/Box2D.NET/B2Islands.cs
@@ -225,7 +225,7 @@ namespace Box2D.NET
             {
                 b2AddContactToIsland(world, islandIdB, contact);
             }
-            
+
             // todo why not merge the islands right here?
         }
 
@@ -395,10 +395,13 @@ namespace Box2D.NET
             }
         }
 
-// Unlink a joint from the island graph when it is destroyed
+        // Unlink a joint from the island graph when it is destroyed
         public static void b2UnlinkJoint(B2World world, B2Joint joint)
         {
-            B2_ASSERT(joint.islandId != B2_NULL_INDEX);
+            if (joint.islandId == B2_NULL_INDEX)
+            {
+                return;
+            }
 
             // remove from island
             int islandId = joint.islandId;
@@ -884,6 +887,11 @@ namespace Box2D.NET
 #if DEBUG
         public static void b2ValidateIsland(B2World world, int islandId)
         {
+            if (islandId == B2_NULL_INDEX)
+            {
+                return;
+            }
+
             B2Island island = b2Array_Get(ref world.islands, islandId);
             B2_ASSERT(island.islandId == islandId);
             B2_ASSERT(island.setIndex != B2_NULL_INDEX);

--- a/src/Box2D.NET/B2Joints.cs
+++ b/src/Box2D.NET/B2Joints.cs
@@ -1595,18 +1595,44 @@ namespace Box2D.NET
 
             if (draw.drawGraphColors)
             {
-                Span<B2HexColor> colors = stackalloc B2HexColor[B2_GRAPH_COLOR_COUNT]
-                {
-                    B2HexColor.b2_colorRed, B2HexColor.b2_colorOrange, B2HexColor.b2_colorYellow, B2HexColor.b2_colorGreen,
-                    B2HexColor.b2_colorCyan, B2HexColor.b2_colorBlue, B2HexColor.b2_colorViolet, B2HexColor.b2_colorPink,
-                    B2HexColor.b2_colorChocolate, B2HexColor.b2_colorGoldenRod, B2HexColor.b2_colorCoral, B2HexColor.b2_colorBlack
+                Span<B2HexColor> graphColors = stackalloc B2HexColor[B2_GRAPH_COLOR_COUNT] {
+                    B2HexColor.b2_colorRed,
+                    B2HexColor.b2_colorOrange,
+                    B2HexColor.b2_colorYellow,
+                    B2HexColor.b2_colorGreen,
+			
+                    B2HexColor.b2_colorCyan,
+                    B2HexColor.b2_colorBlue,
+                    B2HexColor.b2_colorViolet,
+                    B2HexColor.b2_colorPink,
+			
+                    B2HexColor.b2_colorChocolate,
+                    B2HexColor.b2_colorGoldenRod,
+                    B2HexColor.b2_colorCoral,
+                    B2HexColor.b2_colorRosyBrown,
+			
+                    B2HexColor.b2_colorAqua,
+                    B2HexColor.b2_colorPeru,
+                    B2HexColor.b2_colorLime,
+                    B2HexColor.b2_colorGold,
+			
+                    B2HexColor.b2_colorPlum,
+                    B2HexColor.b2_colorSnow,
+                    B2HexColor.b2_colorTeal,
+                    B2HexColor.b2_colorKhaki,
+			
+                    B2HexColor.b2_colorSalmon,
+                    B2HexColor.b2_colorPeachPuff,
+                    B2HexColor.b2_colorHoneyDew,
+                    B2HexColor.b2_colorBlack,
                 };
+
 
                 int colorIndex = joint.colorIndex;
                 if (colorIndex != B2_NULL_INDEX)
                 {
                     B2Vec2 p = b2Lerp(pA, pB, 0.5f);
-                    draw.DrawPointFcn(p, 5.0f, colors[colorIndex], draw.context);
+                    draw.DrawPointFcn( p, 5.0f, graphColors[colorIndex], draw.context );
                 }
             }
 

--- a/src/Box2D.NET/B2Mutex.cs
+++ b/src/Box2D.NET/B2Mutex.cs
@@ -1,0 +1,7 @@
+namespace Box2D.NET
+{
+    public struct B2Mutex
+    {
+        public object lc;
+    }
+}

--- a/src/Box2D.NET/B2Mutexes.cs
+++ b/src/Box2D.NET/B2Mutexes.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+
+namespace Box2D.NET
+{
+    public class B2Mutexes
+    {
+        public static B2Mutex b2CreateMutex()
+        {
+            B2Mutex m = new B2Mutex();
+            m.lc = new object();
+            return m;
+        }
+
+        public static void b2DestroyMutex(ref B2Mutex m)
+        {
+            m.lc = null;
+        }
+
+        public static void b2LockMutex(ref B2Mutex m)
+        {
+            Monitor.Enter(m.lc);
+        }
+
+        public static void b2UnlockMutex(ref B2Mutex m)
+        {
+            Monitor.Exit(m.lc);
+        }
+    }
+}

--- a/src/Box2D.NET/B2SolverSet.cs
+++ b/src/Box2D.NET/B2SolverSet.cs
@@ -7,7 +7,7 @@ using static Box2D.NET.B2Arrays;
 namespace Box2D.NET
 {
     // This holds solver set data. The following sets are used:
-    // - static set for all static bodies (no contacts or joints)
+    // - static set for all static bodies and joints between static bodies
     // - active set for all active bodies with body states (no contacts or joints)
     // - disabled set for disabled bodies and their joints
     // - all further sets are sleeping island sets along with their contacts and joints

--- a/src/Box2D.NET/B2SolverSets.cs
+++ b/src/Box2D.NET/B2SolverSets.cs
@@ -547,7 +547,10 @@ namespace Box2D.NET
 
         public static void b2TransferBody(B2World world, B2SolverSet targetSet, B2SolverSet sourceSet, B2Body body)
         {
-            B2_ASSERT(targetSet != sourceSet);
+            if (targetSet == sourceSet)
+            {
+                return;
+            }
 
             int sourceIndex = body.localIndex;
             B2BodySim sourceSim = b2Array_Get(ref sourceSet.bodySims, sourceIndex);
@@ -556,6 +559,9 @@ namespace Box2D.NET
             ref B2BodySim targetSim = ref b2Array_Add(ref targetSet.bodySims);
             //memcpy( targetSim, sourceSim, sizeof( b2BodySim ) );
             targetSim.CopyFrom(sourceSim);
+
+            // Clear transient body flags
+            targetSim.flags &= ~((uint)B2BodyFlags.b2_isFast | (uint)B2BodyFlags.b2_isSpeedCapped | (uint)B2BodyFlags.b2_hadTimeOfImpact);
 
             // Remove body sim from solver set that owns it
             int movedIndex = b2Array_RemoveSwap(ref sourceSet.bodySims, sourceIndex);
@@ -587,7 +593,10 @@ namespace Box2D.NET
 
         public static void b2TransferJoint(B2World world, B2SolverSet targetSet, B2SolverSet sourceSet, B2Joint joint)
         {
-            B2_ASSERT(targetSet != sourceSet);
+            if (targetSet == sourceSet)
+            {
+                return;
+            }
 
             int localIndex = joint.localIndex;
             int colorIndex = joint.colorIndex;

--- a/src/Box2D.NET/B2Types.cs
+++ b/src/Box2D.NET/B2Types.cs
@@ -168,7 +168,8 @@ namespace Box2D.NET
 
             draw.drawingBounds.lowerBound = new B2Vec2(-float.MaxValue, -float.MaxValue);
             draw.drawingBounds.upperBound = new B2Vec2(float.MaxValue, float.MaxValue);
-            draw.useDrawingBounds = true;
+
+            draw.drawShapes = true;
 
             return draw;
         }

--- a/src/Box2D.NET/B2World.cs
+++ b/src/Box2D.NET/B2World.cs
@@ -79,6 +79,15 @@ namespace Box2D.NET
         public B2Array<B2ContactHitEvent> contactHitEvents;
         public B2Array<B2JointEvent> jointEvents;
 
+        // todo consider deferred waking and impulses to make it possible
+        // to apply forces and impulses from multiple threads
+        // impulses must be deferred because sleeping bodies have no velocity state
+        // Problems:
+        // - multiple forces applied to the same body from multiple threads
+        // Deferred wake
+        //b2BitSet bodyWakeSet;
+        //b2ImpulseArray deferredImpulses;
+
         // Used to track debug draw
         public B2BitSet debugBodySet;
         public B2BitSet debugJointSet;

--- a/test/Box2D.NET.Test/B2DeterminismTest.cs
+++ b/test/Box2D.NET.Test/B2DeterminismTest.cs
@@ -131,8 +131,8 @@ public class b2TaskTester : IDisposable
 
 public class B2DeterminismTest
 {
-    private const int EXPECTED_SLEEP_STEP = 244;
-    private const uint EXPECTED_HASH = 0xfcb96059;
+    private const int EXPECTED_SLEEP_STEP = 320;
+    private const uint EXPECTED_HASH = 0x948FDA81;
 
     private const int e_maxTasks = 128;
 


### PR DESCRIPTION
- Total contact impulse now includes restitution impulse
- Improved tunneling prevention with similar performance
- Graph coloring now puts dynamic-static constraints at higher priority more effectively
- Fixed crash disabling a dynamic body connected to a static body by a joint
- Fixed joint graph color bug when changing body type
- Improved graph color validation using population count
- Added mutex wrappers for future development
- Made spinner benchmark more stressful on solver
- All debug draw now uses the provided camera bounds

box2d https://github.com/erincatto/box2d/pull/956