### PR TITLE
refactor: add span extension helpers for fixed arrays

### DIFF
--- a/src/Box2D.NET/B2FixedArray1.cs
+++ b/src/Box2D.NET/B2FixedArray1.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -21,13 +21,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
     }
 }

--- a/src/Box2D.NET/B2FixedArray1024.cs
+++ b/src/Box2D.NET/B2FixedArray1024.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -1044,13 +1044,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray11.cs
+++ b/src/Box2D.NET/B2FixedArray11.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -31,13 +31,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
     }
 }

--- a/src/Box2D.NET/B2FixedArray12.cs
+++ b/src/Box2D.NET/B2FixedArray12.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -32,13 +32,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray16.cs
+++ b/src/Box2D.NET/B2FixedArray16.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -36,13 +36,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
     }
 }

--- a/src/Box2D.NET/B2FixedArray2.cs
+++ b/src/Box2D.NET/B2FixedArray2.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -28,13 +28,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray24.cs
+++ b/src/Box2D.NET/B2FixedArray24.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -44,13 +44,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray3.cs
+++ b/src/Box2D.NET/B2FixedArray3.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -23,13 +23,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray32.cs
+++ b/src/Box2D.NET/B2FixedArray32.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -52,13 +52,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray4.cs
+++ b/src/Box2D.NET/B2FixedArray4.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -24,13 +24,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
     }
 }

--- a/src/Box2D.NET/B2FixedArray64.cs
+++ b/src/Box2D.NET/B2FixedArray64.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -84,13 +84,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray7.cs
+++ b/src/Box2D.NET/B2FixedArray7.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -27,13 +27,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArray8.cs
+++ b/src/Box2D.NET/B2FixedArray8.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
 // SPDX-License-Identifier: MIT
 
 using System;
@@ -28,13 +28,19 @@ namespace Box2D.NET
         public ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref AsSpan()[index];
+            get => ref AsSpanUnsafe()[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> AsSpan()
+        internal Span<T> AsSpanUnsafe()
         {
             return MemoryMarshal.CreateSpan(ref _v0000, Size);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _v0000), Size);
         }
 
     }

--- a/src/Box2D.NET/B2FixedArrayExtensions.cs
+++ b/src/Box2D.NET/B2FixedArrayExtensions.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 Ikpil Choi(ikpil@naver.com)
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Box2D.NET
+{
+    public static class B2FixedArrayExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray1<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray2<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray3<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray4<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray7<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray8<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray11<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray12<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray16<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray24<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray32<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray64<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ref B2FixedArray1024<T> array) where T : unmanaged
+        {
+            return array.AsSpanUnsafe();
+        }
+    }
+}

--- a/src/Box2D.NET/Box2D.NET.csproj
+++ b/src/Box2D.NET/Box2D.NET.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
@@ -26,4 +26,8 @@
     <DefineConstants>$(DefineConstants);B2_SNOOP_TOI_COUNTERS;ENABLED;B2_SNOOP_TABLE_COUNTERS;B2_SNOOP_PAIR_COUNTERS</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2"/>
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Expose AsSpan through extension methods, add readonly AsReadOnlySpan accessors, and move mutable span creation behind internal AsSpanUnsafe helpers. Add the Unsafe package reference for netstandard2.1.